### PR TITLE
Simplify `ImgCreator` by reducing use of `NativeType` and generic parameters

### DIFF
--- a/src/main/java/qupath/ext/imglib2/AccessibleScaler.java
+++ b/src/main/java/qupath/ext/imglib2/AccessibleScaler.java
@@ -9,7 +9,6 @@ import net.imglib2.realtransform.AffineGet;
 import net.imglib2.realtransform.RealViews;
 import net.imglib2.realtransform.Scale2D;
 import net.imglib2.realtransform.Translation2D;
-import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.view.Views;
 
@@ -40,7 +39,7 @@ public class AccessibleScaler {
      * @throws IllegalArgumentException if the input interval has at least one minimum different from 0, if the provided scale is less
      * than or equal to 0, or if the input interval has less than two dimensions
      */
-    public static <T extends NativeType<T> & NumericType<T>> RandomAccessibleInterval<T> scaleWithLinearInterpolation(
+    public static <T extends NumericType<T>> RandomAccessibleInterval<T> scaleWithLinearInterpolation(
             RandomAccessibleInterval<T> input,
             double scale
     ) {
@@ -59,7 +58,7 @@ public class AccessibleScaler {
      * @throws IllegalArgumentException if the input interval has at least one minimum different from 0, if the provided scale is less
      * than or equal to 0, or if the input interval has less than two dimensions
      */
-    public static <T extends NativeType<T> & NumericType<T>> RandomAccessibleInterval<T> scaleWithNearestNeighborInterpolation(
+    public static <T extends NumericType<T>> RandomAccessibleInterval<T> scaleWithNearestNeighborInterpolation(
             RandomAccessibleInterval<T> input,
             double scale
     ) {
@@ -79,7 +78,7 @@ public class AccessibleScaler {
      * @throws IllegalArgumentException if the input interval has at least one minimum different from 0, if the provided scale is less
      * than or equal to 0, or if the input interval has less than two dimensions
      */
-    public static <T extends NativeType<T> & NumericType<T>> RandomAccessibleInterval<T> scale(
+    public static <T extends NumericType<T>> RandomAccessibleInterval<T> scale(
             RandomAccessibleInterval<T> input,
             double scale,
             InterpolatorFactory<T, RandomAccessible<T>> interpolatorFactory
@@ -104,7 +103,7 @@ public class AccessibleScaler {
         }
     }
 
-    private static <T extends NativeType<T> & NumericType<T>> RandomAccessibleInterval<T> scaleWithoutChecks(
+    private static <T extends NumericType<T>> RandomAccessibleInterval<T> scaleWithoutChecks(
             RandomAccessibleInterval<T> input,
             double scale,
             Scale2D scale2D,

--- a/src/main/java/qupath/ext/imglib2/ImgLib2ImageServer.java
+++ b/src/main/java/qupath/ext/imglib2/ImgLib2ImageServer.java
@@ -96,6 +96,8 @@ public class ImgLib2ImageServer<T extends NativeType<T> & NumericType<T>> extend
      * if the provided accessibles do not have {@link ImgCreator#NUMBER_OF_AXES} axes, if the provided accessibles
      * do not have the same number of channels, z-stacks, or timepoints, or if the accessible type is {@link ARGBType}
      * and the number of channels of the accessibles is not 1
+     * @return the builder
+     * @param <T> Generic parameter for the image type.
      */
     public static <T extends NativeType<T> & NumericType<T>> Builder<T> builder(List<? extends RandomAccessibleInterval<T>> accessibles) {
         return new Builder<>(accessibles);

--- a/src/test/java/qupath/ext/imglib2/TestImgCreator.java
+++ b/src/test/java/qupath/ext/imglib2/TestImgCreator.java
@@ -44,7 +44,7 @@ public class TestImgCreator {
         PixelType pixelType = PixelType.UINT8;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
 
-        Img<ARGBType> img = ImgCreator.builder(imageServer, new ARGBType()).build().createForLevel(0);
+        Img<ARGBType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
 
         Utils.assertArgbRandomAccessibleEquals(img, (x, y, channel, z, t) -> ARGBType.rgba(255, 0, 0, 0), 1);
 
@@ -57,7 +57,7 @@ public class TestImgCreator {
         PixelType pixelType = PixelType.UINT8;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
 
-        Img<UnsignedByteType> img = ImgCreator.builder(imageServer, new UnsignedByteType()).build().createForLevel(0);
+        Img<UnsignedByteType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
 
         Utils.assertRandomAccessibleEquals(img, (x, y, channel, z, t) -> 1, 1);
 
@@ -70,7 +70,7 @@ public class TestImgCreator {
         PixelType pixelType = PixelType.INT8;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
 
-        Img<ByteType> img = ImgCreator.builder(imageServer, new ByteType()).build().createForLevel(0);
+        Img<ByteType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
 
         Utils.assertRandomAccessibleEquals(img, (x, y, channel, z, t) -> 1, 1);
 
@@ -83,7 +83,7 @@ public class TestImgCreator {
         PixelType pixelType = PixelType.UINT16;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
 
-        Img<UnsignedShortType> img = ImgCreator.builder(imageServer, new UnsignedShortType()).build().createForLevel(0);
+        Img<UnsignedShortType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
 
         Utils.assertRandomAccessibleEquals(img, (x, y, channel, z, t) -> 1, 1);
 
@@ -96,7 +96,7 @@ public class TestImgCreator {
         PixelType pixelType = PixelType.INT16;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
 
-        Img<ShortType> img = ImgCreator.builder(imageServer, new ShortType()).build().createForLevel(0);
+        Img<ShortType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
 
         Utils.assertRandomAccessibleEquals(img, (x, y, channel, z, t) -> 1, 1);
 
@@ -109,7 +109,7 @@ public class TestImgCreator {
         PixelType pixelType = PixelType.UINT32;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
 
-        Img<UnsignedIntType> img = ImgCreator.builder(imageServer, new UnsignedIntType()).build().createForLevel(0);
+        Img<UnsignedIntType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
 
         Utils.assertRandomAccessibleEquals(img, (x, y, channel, z, t) -> 1, 1);
 
@@ -122,7 +122,7 @@ public class TestImgCreator {
         PixelType pixelType = PixelType.INT32;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
 
-        Img<IntType> img = ImgCreator.builder(imageServer, new IntType()).build().createForLevel(0);
+        Img<IntType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
 
         Utils.assertRandomAccessibleEquals(img, (x, y, channel, z, t) -> 1, 1);
 
@@ -135,7 +135,7 @@ public class TestImgCreator {
         PixelType pixelType = PixelType.FLOAT32;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
 
-        Img<FloatType> img = ImgCreator.builder(imageServer, new FloatType()).build().createForLevel(0);
+        Img<FloatType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
 
         Utils.assertRandomAccessibleEquals(img, (x, y, channel, z, t) -> 1, 1);
 
@@ -148,7 +148,7 @@ public class TestImgCreator {
         PixelType pixelType = PixelType.FLOAT64;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
 
-        Img<DoubleType> img = ImgCreator.builder(imageServer, new DoubleType()).build().createForLevel(0);
+        Img<DoubleType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
 
         Utils.assertRandomAccessibleEquals(img, (x, y, channel, z, t) -> 1, 1);
 
@@ -221,7 +221,7 @@ public class TestImgCreator {
         ImageServer<BufferedImage> imageServer = new ComplexDoubleImageServer();
         double downsample = imageServer.getDownsampleForResolution(level);
 
-        Img<DoubleType> img = ImgCreator.builder(imageServer, new DoubleType()).build().createForLevel(level);
+        Img<DoubleType> img = ImgCreator.builder(imageServer).build().createForLevel(level);
 
         Utils.assertRandomAccessibleEquals(img, ComplexDoubleImageServer::getPixel, downsample);
 
@@ -234,7 +234,7 @@ public class TestImgCreator {
         ImageServer<BufferedImage> imageServer = new ComplexDoubleImageServer();
         double downsample = imageServer.getDownsampleForResolution(level);
 
-        Img<DoubleType> img = ImgCreator.builder(imageServer, new DoubleType()).build().createForLevel(level);
+        Img<DoubleType> img = ImgCreator.builder(imageServer).build().createForLevel(level);
 
         Utils.assertRandomAccessibleEquals(img, ComplexDoubleImageServer::getPixel, downsample);
 
@@ -247,7 +247,7 @@ public class TestImgCreator {
         ImageServer<BufferedImage> imageServer = new ComplexDoubleImageServer();
         double downsample = imageServer.getDownsampleForResolution(level);
 
-        RandomAccessibleInterval<DoubleType> img = ImgCreator.builder(imageServer, new DoubleType()).build().createForDownsample(downsample);
+        RandomAccessibleInterval<DoubleType> img = ImgCreator.builder(imageServer).build().createForDownsample(downsample);
 
         Utils.assertRandomAccessibleEquals(img, ComplexDoubleImageServer::getPixel, downsample);
 
@@ -260,7 +260,7 @@ public class TestImgCreator {
         ImageServer<BufferedImage> imageServer = new ComplexDoubleImageServer();
         double downsample = imageServer.getDownsampleForResolution(level);
 
-        RandomAccessibleInterval<DoubleType> img = ImgCreator.builder(imageServer, new DoubleType()).build().createForDownsample(downsample);
+        RandomAccessibleInterval<DoubleType> img = ImgCreator.builder(imageServer).build().createForDownsample(downsample);
 
         Utils.assertRandomAccessibleEquals(img, ComplexDoubleImageServer::getPixel, downsample);
 


### PR DESCRIPTION
This tries to substantially reduce the complexity of `ImgCreator`.

The need arose when I was finding it really hard to manage generic parameters of the form `<T extends NativeType<T> & NumericType<T>>`.

Many methods don't/shouldn't care that we have a `NativeType`, but rather only that we have a `NumericType`.

After removing `NativeType` from some locations where it didn't seem needed, it became clear that `ImgCreator` doesn't really need to store the type at all. Rather, the type can be determined from the `ImageServer` at the point the image is requested.

That means it's no longer necessary to provide a type to `ImgCreator.Builder` - making it easier to call.

*Internally* we do still need to always use a `NativeType` so that we can create a `LazyCellImage`. This means we can retain the method signature:
```java
public <T extends NumericType<T> & NativeType<T>> Img<T> createForLevel(int level)
```
so calling code can be confident that the type is both a `NumericType` and a `NativeType` - treating it as either.

**However** I'm not sure if there are risks to this, which undermine compile-time checks. For example the following code looks ok in my IDE:
```java
@Test
    void Check_Rgb_Server() throws Exception {
        boolean isRgb = true;
        PixelType pixelType = PixelType.UINT8;
        try (var imageServer = new GenericImageServer(isRgb, pixelType)) {
            Img<UnsignedByteType> img = ImgCreator.builder(imageServer).build().createForLevel(0);
            Utils.assertRandomAccessibleEquals(img, (x, y, channel, z, t) -> 255, 1);
        }
    }
```
However it fails at runtime with
```
class net.imglib2.type.numeric.ARGBType cannot be cast to class net.imglib2.type.numeric.RealType (net.imglib2.type.numeric.ARGBType and net.imglib2.type.numeric.RealType are in unnamed module of loader 'app')
java.lang.ClassCastException: class net.imglib2.type.numeric.ARGBType cannot be cast to class net.imglib2.type.numeric.RealType (net.imglib2.type.numeric.ARGBType and net.imglib2.type.numeric.RealType are in unnamed module of loader 'app')
	at qupath.ext.imglib2.Utils.assertRandomAccessibleEquals(Utils.java:106)
	at qupath.ext.imglib2.TestImgCreator.Check_Rgb_Server(TestImgCreator.java:47)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
```

I'm not sure if this is a limitation of the way I'm using Java generics here (and we simply need to be checking the type that's returned), or if there's any way we can improve the API further. We would already have had a problem with the previous code if we passed the wrong type, so I don't think we're *worse* off here.