### PR TITLE
Add Realtype builders

### DIFF
--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -107,56 +107,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
         if (server.isRGB()) {
             return new ImgBuilder<>(server, new ARGBType(), ArgbBufferedImageAccess::new, 1);
         } else {
-            return switch (server.getPixelType()) {
-                case UINT8 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedByteType(),
-                        image -> new ByteRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT8 -> new ImgBuilder<>(
-                        server,
-                        new ByteType(),
-                        image -> new ByteRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case UINT16 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedShortType(),
-                        image -> new ShortRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT16 -> new ImgBuilder<>(
-                        server,
-                        new ShortType(),
-                        image -> new ShortRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case UINT32 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedIntType(),
-                        image -> new IntRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT32 -> new ImgBuilder<>(
-                        server,
-                        new IntType(),
-                        image -> new IntRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case FLOAT32 -> new ImgBuilder<>(
-                        server,
-                        new FloatType(),
-                        image -> new FloatRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case FLOAT64 -> new ImgBuilder<>(
-                        server,
-                        new DoubleType(),
-                        image -> new DoubleRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-            };
+            return createRealBuilderFromNonRgbServer(server);
         }
     }
 
@@ -271,56 +222,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
         if (server.isRGB()) {
             return new ImgBuilder<>(server, new UnsignedByteType(), ByteBufferedImageAccess::new, 3);
         } else {
-            return switch (server.getPixelType()) {
-                case UINT8 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedByteType(),
-                        image -> new ByteRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT8 -> new ImgBuilder<>(
-                        server,
-                        new ByteType(),
-                        image -> new ByteRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case UINT16 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedShortType(),
-                        image -> new ShortRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT16 -> new ImgBuilder<>(
-                        server,
-                        new ShortType(),
-                        image -> new ShortRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case UINT32 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedIntType(),
-                        image -> new IntRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT32 -> new ImgBuilder<>(
-                        server,
-                        new IntType(),
-                        image -> new IntRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case FLOAT32 -> new ImgBuilder<>(
-                        server,
-                        new FloatType(),
-                        image -> new FloatRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case FLOAT64 -> new ImgBuilder<>(
-                        server,
-                        new DoubleType(),
-                        image -> new DoubleRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-            };
+            return createRealBuilderFromNonRgbServer(server);
         }
     }
 
@@ -331,45 +233,9 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * <ul>
      *     <li>
      *         If the input image is {@link ImageServer#isRGB() RGB}, the type must be {@link UnsignedByteType}. Images
-     *         created by the returned builder will have 4 channels (RGBA).
+     *         created by the returned builder will have 3 channels (RGB).
      *     </li>
-     *     <li>
-     *         Else:
-     *         <ul>
-     *             <li>
-     *                 If the input image has the {@link PixelType#UINT8} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link UnsignedByteType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#INT8} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link ByteType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#UINT16} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link UnsignedShortType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#INT16} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link ShortType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#UINT32} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link UnsignedIntType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#INT32} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link IntType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#FLOAT32} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link FloatType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#FLOAT64} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link DoubleType}.
-     *             </li>
-     *         </ul>
-     *     </li>
+     *     <li>Else, see {@link #createBuilder(ImageServer, NativeType)}.</li>
      * </ul>
      *
      * @param server the input image
@@ -566,6 +432,59 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
         }
     }
 
+    private static ImgBuilder<? extends RealType<?>, ?> createRealBuilderFromNonRgbServer(ImageServer<BufferedImage> server) {
+        return switch (server.getPixelType()) {
+            case UINT8 -> new ImgBuilder<>(
+                    server,
+                    new UnsignedByteType(),
+                    image -> new ByteRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case INT8 -> new ImgBuilder<>(
+                    server,
+                    new ByteType(),
+                    image -> new ByteRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case UINT16 -> new ImgBuilder<>(
+                    server,
+                    new UnsignedShortType(),
+                    image -> new ShortRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case INT16 -> new ImgBuilder<>(
+                    server,
+                    new ShortType(),
+                    image -> new ShortRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case UINT32 -> new ImgBuilder<>(
+                    server,
+                    new UnsignedIntType(),
+                    image -> new IntRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case INT32 -> new ImgBuilder<>(
+                    server,
+                    new IntType(),
+                    image -> new IntRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case FLOAT32 -> new ImgBuilder<>(
+                    server,
+                    new FloatType(),
+                    image -> new FloatRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case FLOAT64 -> new ImgBuilder<>(
+                    server,
+                    new DoubleType(),
+                    image -> new DoubleRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+        };
+    }
+
     private static <T> void checkType(ImageServer<?> server, T type) {
         if (server.isRGB()) {
             if (!(type instanceof ARGBType)) {
@@ -653,72 +572,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
                 ));
             }
         } else {
-            switch (server.getPixelType()) {
-                case UINT8 -> {
-                    if (!(type instanceof UnsignedByteType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a UnsignedByteType, which is the one expected for non-RGB UINT8 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case INT8 -> {
-                    if (!(type instanceof ByteType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a ByteType, which is the one expected for non-RGB INT8 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case UINT16 -> {
-                    if (!(type instanceof UnsignedShortType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a UnsignedShortType, which is the one expected for non-RGB UINT16 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case INT16 -> {
-                    if (!(type instanceof ShortType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a ShortType, which is the one expected for non-RGB INT16 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case UINT32 -> {
-                    if (!(type instanceof UnsignedIntType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a UnsignedIntType, which is the one expected for non-RGB UINT32 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case INT32 -> {
-                    if (!(type instanceof IntType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a IntType, which is the one expected for non-RGB INT32 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case FLOAT32 -> {
-                    if (!(type instanceof FloatType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a FloatType, which is the one expected for non-RGB FLOAT32 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case FLOAT64 -> {
-                    if (!(type instanceof DoubleType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a DoubleType, which is the one expected for non-RGB FLOAT64 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-            }
+            checkType(server, type);
         }
     }
 

--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -103,7 +103,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * @return a builder to create an instance of this class
      * @throws IllegalArgumentException if the provided image has less than one channel
      */
-    public static ImgBuilder<?, ?> createBuilder(ImageServer<BufferedImage> server) {
+    public static ImgBuilder<? extends NumericType<?>, ?> createBuilder(ImageServer<BufferedImage> server) {
         if (server.isRGB()) {
             return new ImgBuilder<>(server, new ARGBType(), ArgbBufferedImageAccess::new, 1);
         } else {
@@ -267,9 +267,9 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * @return a builder to create an instance of this class
      * @throws IllegalArgumentException if the provided image has less than one channel
      */
-    public static ImgBuilder<?, ?> createRealBuilder(ImageServer<BufferedImage> server) {
+    public static ImgBuilder<? extends RealType<?>, ?> createRealBuilder(ImageServer<BufferedImage> server) {
         if (server.isRGB()) {
-            return new ImgBuilder<>(server, new ARGBType(), ByteBufferedImageAccess::new, 4);
+            return new ImgBuilder<>(server, new UnsignedByteType(), ByteBufferedImageAccess::new, 3);
         } else {
             return switch (server.getPixelType()) {
                 case UINT8 -> new ImgBuilder<>(
@@ -383,7 +383,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
         checkRealType(server, type);
 
         if (server.isRGB()) {
-            return new ImgBuilder<>(server, type, ByteBufferedImageAccess::new, 4);
+            return new ImgBuilder<>(server, type, ByteBufferedImageAccess::new, 3);
         } else {
             return switch (server.getPixelType()) {
                 case UINT8, INT8 -> new ImgBuilder<>(

--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -41,14 +41,16 @@ import java.util.stream.IntStream;
 /**
  * A class to create {@link Img} or {@link RandomAccessibleInterval} from an {@link ImageServer}.
  * <p>
- * Use a {@link #createBuilder(ImageServer)} or {@link #createBuilder(ImageServer, NativeType)} to create an instance of this class.
+ * Use {@link #createBuilder(ImageServer)}, {@link #createBuilder(ImageServer, NumericType)},
+ * {@link #createRealBuilder(ImageServer)} or {@link #createRealBuilder(ImageServer, RealType)} to create an instance
+ * of this class.
  * <p>
  * This class is thread-safe.
  *
  * @param <T> the type of the returned accessibles
  * @param <A> the type contained in the input image
  */
-public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends SizableDataAccess> {
+public class ImgBuilder<T extends NumericType<T> & NativeType<T>, A extends SizableDataAccess> {
 
     /**
      * The index of the X axis of accessibles returned by functions of this class
@@ -96,7 +98,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * Create a builder from an {@link ImageServer}. This doesn't create any accessibles yet.
      * <p>
      * The type of the output image is not checked, which might lead to problems later when accessing pixel values of the
-     * returned accessibles of this class. It is recommended to use {@link #createBuilder(ImageServer, NativeType)} instead.
+     * returned accessibles of this class. It is recommended to use {@link #createBuilder(ImageServer, NumericType)} instead.
      * See also this function to know which pixel type is used.
      *
      * @param server the input image
@@ -166,7 +168,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * @throws IllegalArgumentException if the provided type is not compatible with the input image (see above), or if
      * the provided image has less than one channel
      */
-    public static <T extends NativeType<T> & NumericType<T>> ImgBuilder<T, ?> createBuilder(ImageServer<BufferedImage> server, T type) {
+    public static <T extends NumericType<T> & NativeType<T>> ImgBuilder<T, ?> createBuilder(ImageServer<BufferedImage> server, T type) {
         checkType(server, type);
 
         if (server.isRGB()) {
@@ -211,7 +213,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * Create a builder from an {@link ImageServer}. This doesn't create any accessibles yet.
      * <p>
      * The type of the output image is not checked, which might lead to problems later when accessing pixel values of the
-     * returned accessibles of this class. It is recommended to use {@link #createRealBuilder(ImageServer, NativeType)}
+     * returned accessibles of this class. It is recommended to use {@link #createRealBuilder(ImageServer, RealType)}
      * instead. See also this function to know which pixel type is used.
      *
      * @param server the input image
@@ -235,7 +237,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      *         If the input image is {@link ImageServer#isRGB() RGB}, the type must be {@link UnsignedByteType}. Images
      *         created by the returned builder will have 3 channels (RGB).
      *     </li>
-     *     <li>Else, see {@link #createBuilder(ImageServer, NativeType)}.</li>
+     *     <li>Else, see {@link #createBuilder(ImageServer, NumericType)}.</li>
      * </ul>
      *
      * @param server the input image
@@ -245,7 +247,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * @throws IllegalArgumentException if the provided type is not compatible with the input image (see above), or if
      * the provided image has less than one channel
      */
-    public static <T extends NativeType<T> & RealType<T>> ImgBuilder<T, ?> createRealBuilder(ImageServer<BufferedImage> server, T type) {
+    public static <T extends RealType<T> & NativeType<T>> ImgBuilder<T, ?> createRealBuilder(ImageServer<BufferedImage> server, T type) {
         checkRealType(server, type);
 
         if (server.isRGB()) {

--- a/src/main/java/qupath/ext/imglib2/accesses/ByteBufferedImageAccess.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/ByteBufferedImageAccess.java
@@ -11,10 +11,9 @@ import java.awt.image.DataBufferInt;
 import java.awt.image.SinglePixelPackedSampleModel;
 
 /**
- * An {@link ByteAccess} whose elements are computed from an (A)RGB {@link BufferedImage}.
+ * An {@link ByteAccess} whose elements are computed from an RGB {@link BufferedImage}.
  * <p>
- * If the alpha component is not provided (e.g. if the {@link BufferedImage} has the {@link BufferedImage#TYPE_INT_RGB} type),
- * then the alpha component of each pixel is considered to be 255.
+ * The alpha component is not taken into account.
  * <p>
  * This {@link ByteAccess} is immutable; any attempt to changes its values will result in a
  * {@link UnsupportedOperationException}.
@@ -28,7 +27,6 @@ public class ByteBufferedImageAccess implements ByteAccess, SizableDataAccess, V
     private final int width;
     private final int planeSize;
     private final boolean canUseDataBuffer;
-    private final boolean alphaProvided;
     private final int size;
 
     /**
@@ -46,7 +44,6 @@ public class ByteBufferedImageAccess implements ByteAccess, SizableDataAccess, V
 
         this.canUseDataBuffer = image.getRaster().getDataBuffer() instanceof DataBufferInt &&
                 image.getRaster().getSampleModel() instanceof SinglePixelPackedSampleModel;
-        this.alphaProvided = image.getType() == BufferedImage.TYPE_INT_ARGB;
 
         this.size = AccessTools.getSizeOfDataBufferInBytes(this.dataBuffer);
     }
@@ -64,13 +61,6 @@ public class ByteBufferedImageAccess implements ByteAccess, SizableDataAccess, V
             case 0 -> (byte) ColorTools.red(pixel);
             case 1 -> (byte) ColorTools.green(pixel);
             case 2 -> (byte) ColorTools.blue(pixel);
-            case 3 -> {
-                if (alphaProvided) {
-                    yield (byte) ColorTools.alpha(pixel);
-                } else {
-                    yield (byte) 255;
-                }
-            }
             default -> throw new IllegalArgumentException(String.format("The provided index %d is out of bounds", index));
         };
     }


### PR DESCRIPTION
Add new functions `createRealBuilder()` to create instances of `ImgBuilder` with the `RealType` type. Basically, a RGB image server is converted to a 4-channels `UnsignedByteType` image (instead of being converted to a single-channel `ARGBType` image with the existing `createBuilder()` functions).

This required to add a new `ByteBufferedImageAccess` to get `byte` pixels from a RGB `BufferedImage`.

The justification for this PR is that `RealType` is quite easy to work with, unlike `ARGBType`.

If this PR makes sense, shouldn't we delete the existing `createBuilder()` functions? Would they still be used for anything?

This PR is a draft until we agree on its content, because tests have to be added.