### PR TITLE
Trying to simplify

### DIFF
--- a/src/main/java/qupath/ext/imglib2/AccessibleScaler.java
+++ b/src/main/java/qupath/ext/imglib2/AccessibleScaler.java
@@ -9,7 +9,6 @@ import net.imglib2.realtransform.AffineGet;
 import net.imglib2.realtransform.RealViews;
 import net.imglib2.realtransform.Scale2D;
 import net.imglib2.realtransform.Translation2D;
-import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.view.Views;
 
@@ -40,7 +39,7 @@ public class AccessibleScaler {
      * @throws IllegalArgumentException if the input interval has at least one minimum different from 0, if the provided scale is less
      * than or equal to 0, or if the input interval has less than two dimensions
      */
-    public static <T extends NativeType<T> & NumericType<T>> RandomAccessibleInterval<T> scaleWithLinearInterpolation(
+    public static <T extends NumericType<T>> RandomAccessibleInterval<T> scaleWithLinearInterpolation(
             RandomAccessibleInterval<T> input,
             double scale
     ) {
@@ -59,7 +58,7 @@ public class AccessibleScaler {
      * @throws IllegalArgumentException if the input interval has at least one minimum different from 0, if the provided scale is less
      * than or equal to 0, or if the input interval has less than two dimensions
      */
-    public static <T extends NativeType<T> & NumericType<T>> RandomAccessibleInterval<T> scaleWithNearestNeighborInterpolation(
+    public static <T> RandomAccessibleInterval<T> scaleWithNearestNeighborInterpolation(
             RandomAccessibleInterval<T> input,
             double scale
     ) {
@@ -79,7 +78,7 @@ public class AccessibleScaler {
      * @throws IllegalArgumentException if the input interval has at least one minimum different from 0, if the provided scale is less
      * than or equal to 0, or if the input interval has less than two dimensions
      */
-    public static <T extends NativeType<T> & NumericType<T>> RandomAccessibleInterval<T> scale(
+    public static <T> RandomAccessibleInterval<T> scale(
             RandomAccessibleInterval<T> input,
             double scale,
             InterpolatorFactory<T, RandomAccessible<T>> interpolatorFactory
@@ -104,7 +103,7 @@ public class AccessibleScaler {
         }
     }
 
-    private static <T extends NativeType<T> & NumericType<T>> RandomAccessibleInterval<T> scaleWithoutChecks(
+    private static <T> RandomAccessibleInterval<T> scaleWithoutChecks(
             RandomAccessibleInterval<T> input,
             double scale,
             Scale2D scale2D,

--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -488,7 +488,7 @@ public class ImgBuilder<T> {
      * @param <T> generic parameter for the type
      */
     @SuppressWarnings("unchecked")
-    private static <T extends RealType<T>> T getRealType(PixelType pixelType) {
+    public static <T extends RealType<T>> T getRealType(PixelType pixelType) {
         Objects.requireNonNull(pixelType, "Pixel type must not be null");
         return switch (pixelType) {
             case UINT8 -> (T)new UnsignedByteType();
@@ -501,5 +501,6 @@ public class ImgBuilder<T> {
             case FLOAT64 -> (T)new DoubleType();
         };
     }
+    
 
 }

--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -48,7 +48,7 @@ import java.util.stream.IntStream;
  *
  * @param <T> the type of the returned accessibles
  */
-public class ImgBuilder<T> {
+public class ImgBuilder<T extends NumericType<T>> {
 
     /**
      * The index of the X axis of accessibles returned by functions of this class
@@ -286,6 +286,7 @@ public class ImgBuilder<T> {
         if (type instanceof NativeType<?>) {
             return createLazyImage((NativeType)type, level);
         } else {
+            // This code should not be reached, since we checked the type in the constructor
             throw new IllegalArgumentException(type + " is not an instanceof NativeType");
         }
     }
@@ -367,10 +368,9 @@ public class ImgBuilder<T> {
         int level = ServerTools.getPreferredResolutionLevel(server, downsample);
         RandomAccessibleInterval<T> imgLevel = buildForLevel(level);
 
-        if (server.getMetadata().getChannelType() != ImageServerMetadata.ChannelType.CLASSIFICATION &&
-            imgLevel.getType() instanceof NumericType<?>) {
+        if (server.getMetadata().getChannelType() != ImageServerMetadata.ChannelType.CLASSIFICATION) {
             return AccessibleScaler.scaleWithLinearInterpolation(
-                    (RandomAccessibleInterval)imgLevel,
+                    imgLevel,
                     server.getDownsampleForResolution(level) / downsample
             );
         } else {

--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -107,56 +107,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
         if (server.isRGB()) {
             return new ImgBuilder<>(server, new ARGBType(), ArgbBufferedImageAccess::new, 1);
         } else {
-            return switch (server.getPixelType()) {
-                case UINT8 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedByteType(),
-                        image -> new ByteRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT8 -> new ImgBuilder<>(
-                        server,
-                        new ByteType(),
-                        image -> new ByteRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case UINT16 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedShortType(),
-                        image -> new ShortRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT16 -> new ImgBuilder<>(
-                        server,
-                        new ShortType(),
-                        image -> new ShortRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case UINT32 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedIntType(),
-                        image -> new IntRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT32 -> new ImgBuilder<>(
-                        server,
-                        new IntType(),
-                        image -> new IntRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case FLOAT32 -> new ImgBuilder<>(
-                        server,
-                        new FloatType(),
-                        image -> new FloatRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case FLOAT64 -> new ImgBuilder<>(
-                        server,
-                        new DoubleType(),
-                        image -> new DoubleRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-            };
+            return createRealBuilderFromNonRgbServer(server);
         }
     }
 
@@ -271,56 +222,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
         if (server.isRGB()) {
             return new ImgBuilder<>(server, new UnsignedByteType(), ByteBufferedImageAccess::new, 3);
         } else {
-            return switch (server.getPixelType()) {
-                case UINT8 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedByteType(),
-                        image -> new ByteRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT8 -> new ImgBuilder<>(
-                        server,
-                        new ByteType(),
-                        image -> new ByteRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case UINT16 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedShortType(),
-                        image -> new ShortRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT16 -> new ImgBuilder<>(
-                        server,
-                        new ShortType(),
-                        image -> new ShortRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case UINT32 -> new ImgBuilder<>(
-                        server,
-                        new UnsignedIntType(),
-                        image -> new IntRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case INT32 -> new ImgBuilder<>(
-                        server,
-                        new IntType(),
-                        image -> new IntRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case FLOAT32 -> new ImgBuilder<>(
-                        server,
-                        new FloatType(),
-                        image -> new FloatRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-                case FLOAT64 -> new ImgBuilder<>(
-                        server,
-                        new DoubleType(),
-                        image -> new DoubleRasterAccess(image.getRaster()),
-                        server.nChannels()
-                );
-            };
+            return createRealBuilderFromNonRgbServer(server);
         }
     }
 
@@ -331,45 +233,9 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * <ul>
      *     <li>
      *         If the input image is {@link ImageServer#isRGB() RGB}, the type must be {@link UnsignedByteType}. Images
-     *         created by the returned builder will have 4 channels (RGBA).
+     *         created by the returned builder will have 3 channels (RGB).
      *     </li>
-     *     <li>
-     *         Else:
-     *         <ul>
-     *             <li>
-     *                 If the input image has the {@link PixelType#UINT8} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link UnsignedByteType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#INT8} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link ByteType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#UINT16} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link UnsignedShortType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#INT16} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link ShortType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#UINT32} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link UnsignedIntType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#INT32} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link IntType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#FLOAT32} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link FloatType}.
-     *             </li>
-     *             <li>
-     *                 If the input image has the {@link PixelType#FLOAT64} {@link ImageServer#getPixelType() pixel type},
-     *                 the type must be {@link DoubleType}.
-     *             </li>
-     *         </ul>
-     *     </li>
+     *     <li>Else, see {@link #createBuilder(ImageServer, NativeType)}.</li>
      * </ul>
      *
      * @param server the input image
@@ -566,6 +432,59 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
         }
     }
 
+    private static ImgBuilder<? extends RealType<?>, ?> createRealBuilderFromNonRgbServer(ImageServer<BufferedImage> server) {
+        return switch (server.getPixelType()) {
+            case UINT8 -> new ImgBuilder<>(
+                    server,
+                    new UnsignedByteType(),
+                    image -> new ByteRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case INT8 -> new ImgBuilder<>(
+                    server,
+                    new ByteType(),
+                    image -> new ByteRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case UINT16 -> new ImgBuilder<>(
+                    server,
+                    new UnsignedShortType(),
+                    image -> new ShortRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case INT16 -> new ImgBuilder<>(
+                    server,
+                    new ShortType(),
+                    image -> new ShortRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case UINT32 -> new ImgBuilder<>(
+                    server,
+                    new UnsignedIntType(),
+                    image -> new IntRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case INT32 -> new ImgBuilder<>(
+                    server,
+                    new IntType(),
+                    image -> new IntRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case FLOAT32 -> new ImgBuilder<>(
+                    server,
+                    new FloatType(),
+                    image -> new FloatRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+            case FLOAT64 -> new ImgBuilder<>(
+                    server,
+                    new DoubleType(),
+                    image -> new DoubleRasterAccess(image.getRaster()),
+                    server.nChannels()
+            );
+        };
+    }
+
     private static <T> void checkType(ImageServer<?> server, T type) {
         if (server.isRGB()) {
             if (!(type instanceof ARGBType)) {
@@ -653,72 +572,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
                 ));
             }
         } else {
-            switch (server.getPixelType()) {
-                case UINT8 -> {
-                    if (!(type instanceof UnsignedByteType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a UnsignedByteType, which is the one expected for non-RGB UINT8 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case INT8 -> {
-                    if (!(type instanceof ByteType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a ByteType, which is the one expected for non-RGB INT8 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case UINT16 -> {
-                    if (!(type instanceof UnsignedShortType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a UnsignedShortType, which is the one expected for non-RGB UINT16 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case INT16 -> {
-                    if (!(type instanceof ShortType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a ShortType, which is the one expected for non-RGB INT16 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case UINT32 -> {
-                    if (!(type instanceof UnsignedIntType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a UnsignedIntType, which is the one expected for non-RGB UINT32 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case INT32 -> {
-                    if (!(type instanceof IntType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a IntType, which is the one expected for non-RGB INT32 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case FLOAT32 -> {
-                    if (!(type instanceof FloatType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a FloatType, which is the one expected for non-RGB FLOAT32 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-                case FLOAT64 -> {
-                    if (!(type instanceof DoubleType)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The provided type %s is not a DoubleType, which is the one expected for non-RGB FLOAT64 images",
-                                type.getClass()
-                        ));
-                    }
-                }
-            }
+            checkType(server, type);
         }
     }
 

--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -103,7 +103,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * @return a builder to create an instance of this class
      * @throws IllegalArgumentException if the provided image has less than one channel
      */
-    public static ImgBuilder<?, ?> createBuilder(ImageServer<BufferedImage> server) {
+    public static ImgBuilder<? extends NumericType<?>, ?> createBuilder(ImageServer<BufferedImage> server) {
         if (server.isRGB()) {
             return new ImgBuilder<>(server, new ARGBType(), ArgbBufferedImageAccess::new, 1);
         } else {
@@ -267,9 +267,9 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * @return a builder to create an instance of this class
      * @throws IllegalArgumentException if the provided image has less than one channel
      */
-    public static ImgBuilder<?, ?> createRealBuilder(ImageServer<BufferedImage> server) {
+    public static ImgBuilder<? extends RealType<?>, ?> createRealBuilder(ImageServer<BufferedImage> server) {
         if (server.isRGB()) {
-            return new ImgBuilder<>(server, new ARGBType(), ByteBufferedImageAccess::new, 4);
+            return new ImgBuilder<>(server, new UnsignedByteType(), ByteBufferedImageAccess::new, 3);
         } else {
             return switch (server.getPixelType()) {
                 case UINT8 -> new ImgBuilder<>(
@@ -383,7 +383,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
         checkRealType(server, type);
 
         if (server.isRGB()) {
-            return new ImgBuilder<>(server, type, ByteBufferedImageAccess::new, 4);
+            return new ImgBuilder<>(server, type, ByteBufferedImageAccess::new, 3);
         } else {
             return switch (server.getPixelType()) {
                 case UINT8, INT8 -> new ImgBuilder<>(

--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -384,7 +384,7 @@ public class ImgBuilder<T extends NumericType<T>> {
             }
         } else {
             var pixelType = server.getPixelType();
-            var expectedType = getRealType(pixelType);
+            var expectedType = getRealTypeUnsafe(pixelType);
             if (!expectedType.getClass().isInstance(type)) {
                 throw new IllegalArgumentException(String.format(
                         "The provided type %s is not %s, which is the one expected for %s images",
@@ -447,7 +447,7 @@ public class ImgBuilder<T extends NumericType<T>> {
         if (server.isRGB())
             return (T)getRgbType();
         else
-            return (T)getRealType(server.getPixelType());
+            return (T)getRealTypeUnsafe(server.getPixelType());
     }
 
     /**
@@ -467,7 +467,7 @@ public class ImgBuilder<T extends NumericType<T>> {
      * @return the default real type to create images for this server
      */
     public static RealType<?> getRealType(ImageServer<?> server) {
-        return getRealType(server.getPixelType());
+        return getRealTypeUnsafe(server.getPixelType());
     }
 
     /**

--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -41,14 +41,16 @@ import java.util.stream.IntStream;
 /**
  * A class to create {@link Img} or {@link RandomAccessibleInterval} from an {@link ImageServer}.
  * <p>
- * Use a {@link #createBuilder(ImageServer)} or {@link #createBuilder(ImageServer, NativeType)} to create an instance of this class.
+ * Use {@link #createBuilder(ImageServer)}, {@link #createBuilder(ImageServer, NumericType)},
+ * {@link #createRealBuilder(ImageServer)} or {@link #createRealBuilder(ImageServer, RealType)} to create an instance
+ * of this class.
  * <p>
  * This class is thread-safe.
  *
  * @param <T> the type of the returned accessibles
  * @param <A> the type contained in the input image
  */
-public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends SizableDataAccess> {
+public class ImgBuilder<T extends NumericType<T> & NativeType<T>, A extends SizableDataAccess> {
 
     /**
      * The index of the X axis of accessibles returned by functions of this class
@@ -96,7 +98,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * Create a builder from an {@link ImageServer}. This doesn't create any accessibles yet.
      * <p>
      * The type of the output image is not checked, which might lead to problems later when accessing pixel values of the
-     * returned accessibles of this class. It is recommended to use {@link #createBuilder(ImageServer, NativeType)} instead.
+     * returned accessibles of this class. It is recommended to use {@link #createBuilder(ImageServer, NumericType)} instead.
      * See also this function to know which pixel type is used.
      *
      * @param server the input image
@@ -166,7 +168,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * @throws IllegalArgumentException if the provided type is not compatible with the input image (see above), or if
      * the provided image has less than one channel
      */
-    public static <T extends NativeType<T> & NumericType<T>> ImgBuilder<T, ?> createBuilder(ImageServer<BufferedImage> server, T type) {
+    public static <T extends NumericType<T> & NativeType<T>> ImgBuilder<T, ?> createBuilder(ImageServer<BufferedImage> server, T type) {
         checkType(server, type);
 
         if (server.isRGB()) {
@@ -211,7 +213,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * Create a builder from an {@link ImageServer}. This doesn't create any accessibles yet.
      * <p>
      * The type of the output image is not checked, which might lead to problems later when accessing pixel values of the
-     * returned accessibles of this class. It is recommended to use {@link #createRealBuilder(ImageServer, NativeType)}
+     * returned accessibles of this class. It is recommended to use {@link #createRealBuilder(ImageServer, RealType)}
      * instead. See also this function to know which pixel type is used.
      *
      * @param server the input image
@@ -235,7 +237,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      *         If the input image is {@link ImageServer#isRGB() RGB}, the type must be {@link UnsignedByteType}. Images
      *         created by the returned builder will have 3 channels (RGB).
      *     </li>
-     *     <li>Else, see {@link #createBuilder(ImageServer, NativeType)}.</li>
+     *     <li>Else, see {@link #createBuilder(ImageServer, NumericType)}.</li>
      * </ul>
      *
      * @param server the input image
@@ -245,7 +247,7 @@ public class ImgBuilder<T extends NativeType<T> & NumericType<T>, A extends Siza
      * @throws IllegalArgumentException if the provided type is not compatible with the input image (see above), or if
      * the provided image has less than one channel
      */
-    public static <T extends NativeType<T> & RealType<T>> ImgBuilder<T, ?> createRealBuilder(ImageServer<BufferedImage> server, T type) {
+    public static <T extends RealType<T> & NativeType<T>> ImgBuilder<T, ?> createRealBuilder(ImageServer<BufferedImage> server, T type) {
         checkRealType(server, type);
 
         if (server.isRGB()) {

--- a/src/main/java/qupath/ext/imglib2/ImgBuilder.java
+++ b/src/main/java/qupath/ext/imglib2/ImgBuilder.java
@@ -117,8 +117,9 @@ public class ImgBuilder<T extends NumericType<T>> {
      * The provided type must be compatible with the input image:
      * <ul>
      *     <li>
-     *         If the input image is {@link ImageServer#isRGB() RGB}, the type must be {@link ARGBType}. Images created
-     *         by the returned builder will have one channel.
+     *         If the input image is {@link ImageServer#isRGB() RGB}, the type may be {@link ARGBType}, in which case
+     *         images created by the returned builder will have one channel.
+     *         Alternatively, the type may be {@link UnsignedByteType} and the image will have three channels.
      *     </li>
      *     <li>
      *         Else:
@@ -213,7 +214,7 @@ public class ImgBuilder<T extends NumericType<T>> {
      * @param server the input image
      * @return a builder to create an instance of this class
      * @throws IllegalArgumentException if the provided type is not compatible with the input image (see above), or if
-     *      * the provided image has less than one channel
+     *         the provided image has less than one channel
      * @see #createRgbBuilder(ImageServer)
      */
     public static <T extends RealType<T>> ImgBuilder<T> createRealBuilder(ImageServer<BufferedImage> server, T type) {
@@ -441,7 +442,7 @@ public class ImgBuilder<T extends NumericType<T>> {
         return getDefaultTypeUnsafe(server);
     }
 
-    @SuppressWarnings("unchecked") // Private method, used internally
+    @SuppressWarnings("unchecked") // Private method - must only be used internally with appropriate return value
     private static <T extends NumericType<T>> T getDefaultTypeUnsafe(ImageServer<?> server) {
         if (server.isRGB())
             return (T)getRgbType();
@@ -485,7 +486,7 @@ public class ImgBuilder<T extends NumericType<T>> {
         return getRealTypeUnsafe(pixelType);
     }
 
-    @SuppressWarnings("unchecked") // Private method
+    @SuppressWarnings("unchecked") // Private method - must only be used internally with appropriate return value
     private static <T extends RealType<T>> T getRealTypeUnsafe(PixelType pixelType) {
         Objects.requireNonNull(pixelType, "Pixel type must not be null");
         return switch (pixelType) {

--- a/src/main/java/qupath/ext/imglib2/accesses/ByteBufferedImageAccess.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/ByteBufferedImageAccess.java
@@ -11,10 +11,9 @@ import java.awt.image.DataBufferInt;
 import java.awt.image.SinglePixelPackedSampleModel;
 
 /**
- * An {@link ByteAccess} whose elements are computed from an (A)RGB {@link BufferedImage}.
+ * An {@link ByteAccess} whose elements are computed from an RGB {@link BufferedImage}.
  * <p>
- * If the alpha component is not provided (e.g. if the {@link BufferedImage} has the {@link BufferedImage#TYPE_INT_RGB} type),
- * then the alpha component of each pixel is considered to be 255.
+ * The alpha component is not taken into account.
  * <p>
  * This {@link ByteAccess} is immutable; any attempt to changes its values will result in a
  * {@link UnsupportedOperationException}.
@@ -28,7 +27,6 @@ public class ByteBufferedImageAccess implements ByteAccess, SizableDataAccess, V
     private final int width;
     private final int planeSize;
     private final boolean canUseDataBuffer;
-    private final boolean alphaProvided;
     private final int size;
 
     /**
@@ -46,7 +44,6 @@ public class ByteBufferedImageAccess implements ByteAccess, SizableDataAccess, V
 
         this.canUseDataBuffer = image.getRaster().getDataBuffer() instanceof DataBufferInt &&
                 image.getRaster().getSampleModel() instanceof SinglePixelPackedSampleModel;
-        this.alphaProvided = image.getType() == BufferedImage.TYPE_INT_ARGB;
 
         this.size = AccessTools.getSizeOfDataBufferInBytes(this.dataBuffer);
     }
@@ -64,13 +61,6 @@ public class ByteBufferedImageAccess implements ByteAccess, SizableDataAccess, V
             case 0 -> (byte) ColorTools.red(pixel);
             case 1 -> (byte) ColorTools.green(pixel);
             case 2 -> (byte) ColorTools.blue(pixel);
-            case 3 -> {
-                if (alphaProvided) {
-                    yield (byte) ColorTools.alpha(pixel);
-                } else {
-                    yield (byte) 255;
-                }
-            }
             default -> throw new IllegalArgumentException(String.format("The provided index %d is out of bounds", index));
         };
     }

--- a/src/test/java/qupath/ext/imglib2/TestImgBuilder.java
+++ b/src/test/java/qupath/ext/imglib2/TestImgBuilder.java
@@ -42,8 +42,10 @@ public class TestImgBuilder {
         boolean isRgb = false;
         PixelType pixelType = PixelType.UINT8;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
+
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> ImgBuilder.createBuilder(imageServer, new FloatType()).buildForLevel(0));
+        
         imageServer.close();
     }
 
@@ -52,11 +54,13 @@ public class TestImgBuilder {
         boolean isRgb = false;
         PixelType pixelType = PixelType.UINT8;
         ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
+
         Assertions.assertThrows(ClassCastException.class,
                 () -> {
                     FloatType myType = ImgBuilder.getRealType(imageServer.getPixelType());
                     ImgBuilder.createBuilder(imageServer, myType).buildForLevel(0);
                 });
+
         imageServer.close();
     }
 

--- a/src/test/java/qupath/ext/imglib2/TestImgBuilder.java
+++ b/src/test/java/qupath/ext/imglib2/TestImgBuilder.java
@@ -45,7 +45,7 @@ public class TestImgBuilder {
 
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> ImgBuilder.createBuilder(imageServer, new FloatType()).buildForLevel(0));
-        
+
         imageServer.close();
     }
 

--- a/src/test/java/qupath/ext/imglib2/TestImgBuilder.java
+++ b/src/test/java/qupath/ext/imglib2/TestImgBuilder.java
@@ -38,6 +38,29 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class TestImgBuilder {
 
     @Test
+    void Check_Fail_Fast() throws Exception {
+        boolean isRgb = false;
+        PixelType pixelType = PixelType.UINT8;
+        ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ImgBuilder.createBuilder(imageServer, new FloatType()).buildForLevel(0));
+        imageServer.close();
+    }
+
+    @Test
+    void Check_Fail_With_Wrong_Type() throws Exception {
+        boolean isRgb = false;
+        PixelType pixelType = PixelType.UINT8;
+        ImageServer<BufferedImage> imageServer = new GenericImageServer(isRgb, pixelType);
+        Assertions.assertThrows(ClassCastException.class,
+                () -> {
+                    FloatType myType = ImgBuilder.getRealType(imageServer.getPixelType());
+                    ImgBuilder.createBuilder(imageServer, myType).buildForLevel(0);
+                });
+        imageServer.close();
+    }
+
+    @Test
     void Check_Rgb_Server() throws Exception {
         boolean isRgb = true;
         PixelType pixelType = PixelType.UINT8;


### PR DESCRIPTION
This builds on top of https://github.com/qupath/qupath-imglib2/pull/16 with the goal of trying to reduce boilerplate and make it easier to code for not knowing the image type - which is the 'usual' case in QuPath.

Some changes:
* Most methods in `AccessibleScaler` are very generic - so don't restrict their inputs so much (e.g. don't need a `NativeType`, and sometimes even `NumericType`)
* We never need to care about the second generic parameter for `ImgBuilder<T,A>` - so simplify it to `ImgBuilder<T>`
* Reduce the number and length of `switch` statements
* Add method for `createRgbBuilder` to go along with `createRealBuilder`

The last is to support this kind of code without the user having to know that `ARGBType` is what they need:
```java
if (server.isRGB()) {
   // Handle RGB with known type
} else {
   // Handle everything else with real type
}
```

Then there's another change that I think will be more controversial:
* Add method `public static <T extends RealType<T>> T getRealType(PixelType pixelType)`

This is another generic method where the generic is only in the return value - so I documented why it isn't a good idea.

Still, the point of having it is to support this kind of code where the type is defined for the method:
```java
public static <T extends RealType<T>> void doSomething() {
        try (var server = ImageServers.buildServer("")) {
            T typeGeneric = getRealType(server.getPixelType());
            RandomAccessibleInterval<T> imgGeneric = ImgBuilder.createBuilder(server, typeGeneric).buildForLevel(0);
            Views.collapseReal(imgGeneric);
        } catch (Exception e) {
            e.printStackTrace();
        }
}
```

I'm not sure this was possible with https://github.com/qupath/qupath-imglib2/pull/16 because returning `ImgBuilder<? extends NumericType<?>, ?>` when the type wasn't known seemed too aggressive in throwing away information. Unless there was a safer syntax I missed, I think it pushes people towards using raw types or really large switch statements - both of which rather go against the point of Java generics and ImgLib2's purpose.

A big disadvantage is that it's *possible* to do something like this
```java
FloatType type = ImgBuilder.getRealType(PixelType.UINT8);
```
_however_ an exception should be thrown as soon as the type is used to create an image with an incompatible server, which I think mitigates the risk. At least it seems less dangerous than my previous attempts, which could allow this kind of thing
```java
RandomAccessibleInterval<FloatType> img = ImgBuilder.createBuilder(server).buildForLevel(0)
```
and have the error show up *much* later.

----

The ultimate goal was to try to figure out some safer syntax that was also intuitive. This didn't really work out.
The method below is some code that I added at the end of `ImgBuilder`, which can be used to explore my attempts to see what did and didn't work (spoiler: most things don't work).
```java
    public static <T extends RealType<T>> void doSomething(String[] args) {
            try (var server = ImageServers.buildServer("")) {
    
                // This works - use the generic parameter of the method
                T typeGeneric = getRealType(server.getPixelType());
                RandomAccessibleInterval<T> imgGeneric = ImgBuilder.createBuilder(server, typeGeneric).buildForLevel(0);
                Views.collapseReal(imgGeneric);
    
                // Doesn't compile - it's not ok to request real type inline
                var imgInline = ImgBuilder.createRealBuilder(server, getRealType(server.getPixelType())).buildForLevel(0);
                Views.collapseReal(imgInline);
    
                // Doesn't compile - need to specify a compatible type, RealType<?> isn't enough
                var imgUnsafe = ImgBuilder.createRealBuilder(server).buildForLevel(0);
                Views.collapseReal(imgUnsafe);
    
                // Doesn't compile - the fact we have a RealType doesn't manage to get through
                var imgUnreal = ImgBuilder.createBuilder(server, getRealType(server.getPixelType())).buildForLevel(0);
                Views.collapseReal(imgUnreal);
    
                // Doesn't compile - fails at buildForLevel (and we may well *not* have a FloatType)
                RandomAccessibleInterval<FloatType> imgDubious = ImgBuilder.createRealBuilder(server, getRealType(server.getPixelType())).buildForLevel(0);
                Views.collapseReal(imgDubious);
    
                // Doesn't compile - type only works if it's inline (for some reason)
                var typeUnknown = getRealType(server.getPixelType());
                var imgOutline = ImgBuilder.createRealBuilder(server, typeUnknown).buildForLevel(0);
                Views.collapseReal(imgOutline);
    
                // This compiles - but should fail when wrong type is passed to builder
                FloatType tf = getRealType(server.getPixelType()); // Might well be wrong!
                RandomAccessibleInterval<FloatType> img6 = ImgBuilder.createRealBuilder(server, tf).buildForLevel(0);
                Views.collapseReal(img6);
    
            } catch (Exception e) {
                e.printStackTrace();
            }
        }
```

I used `Views.collapseReal` because it has this signature:
```java
public static < T extends RealType< T > > CompositeIntervalView< T, RealComposite< T > > collapseReal( final RandomAccessibleInterval< T > source )
```
and I wanted to see could be go from any arbitrary `ImageServer` to `RandomAccessibleInterval<T>` where we know that `T` is an instance of `RealType` but we *don't* know what exactly it is.