### PR TITLE
More accurate interpolation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.github.qupath"
-version = "0.1.0"
+version = "0.1.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/qupath/ext/imglib2/AccessibleScaler.java
+++ b/src/main/java/qupath/ext/imglib2/AccessibleScaler.java
@@ -3,7 +3,6 @@ package qupath.ext.imglib2;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.interpolation.InterpolatorFactory;
-import net.imglib2.interpolation.randomaccess.NLinearInterpolatorFactory;
 import net.imglib2.interpolation.randomaccess.NearestNeighborInterpolatorFactory;
 import net.imglib2.realtransform.AffineGet;
 import net.imglib2.realtransform.RealViews;
@@ -11,6 +10,7 @@ import net.imglib2.realtransform.Scale2D;
 import net.imglib2.realtransform.Translation2D;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.view.Views;
+import qupath.ext.imglib2.interpolators.LinearInterpolationFactory;
 
 import java.util.Arrays;
 import java.util.stream.LongStream;
@@ -35,15 +35,16 @@ public class AccessibleScaler {
      * @param scale the scale to apply to the first two dimensions of the input {@link RandomAccessibleInterval}. Shouldn't be
      *              less than or equal to 0
      * @return the input if the provided scale is 1, or a new scaled {@link RandomAccessibleInterval} otherwise
-     * @param <T> the type of elements of the random accessible interval
+     * @param <T> the type of elements of the random accessible interval. It must be {@link net.imglib2.type.numeric.ARGBType}
+     *            or an instance of {@link net.imglib2.type.numeric.RealType}
      * @throws IllegalArgumentException if the input interval has at least one minimum different from 0, if the provided scale is less
-     * than or equal to 0, or if the input interval has less than two dimensions
+     * than or equal to 0, if the input interval has less than two dimensions, or if the type T is invalid (see above)
      */
     public static <T extends NumericType<T>> RandomAccessibleInterval<T> scaleWithLinearInterpolation(
             RandomAccessibleInterval<T> input,
             double scale
     ) {
-        return scale(input, scale, new NLinearInterpolatorFactory<>());
+        return scale(input, scale, new LinearInterpolationFactory<>());
     }
 
     /**

--- a/src/main/java/qupath/ext/imglib2/AccessibleScaler.java
+++ b/src/main/java/qupath/ext/imglib2/AccessibleScaler.java
@@ -36,9 +36,10 @@ public class AccessibleScaler {
      *              less than or equal to 0
      * @return the input if the provided scale is 1, or a new scaled {@link RandomAccessibleInterval} otherwise
      * @param <T> the type of elements of the random accessible interval. It must be {@link net.imglib2.type.numeric.ARGBType}
-     *            or an instance of {@link net.imglib2.type.numeric.RealType}
+     *            or an instance of {@link net.imglib2.type.numeric.RealType}, otherwise a {@link IllegalArgumentException}
+     *            will be thrown when accessing the output
      * @throws IllegalArgumentException if the input interval has at least one minimum different from 0, if the provided scale is less
-     * than or equal to 0, if the input interval has less than two dimensions, or if the type T is invalid (see above)
+     * than or equal to 0, or if the input interval has less than two dimensions
      */
     public static <T extends NumericType<T>> RandomAccessibleInterval<T> scaleWithLinearInterpolation(
             RandomAccessibleInterval<T> input,

--- a/src/main/java/qupath/ext/imglib2/interpolators/ArgbLinearInterpolator.java
+++ b/src/main/java/qupath/ext/imglib2/interpolators/ArgbLinearInterpolator.java
@@ -1,0 +1,65 @@
+package qupath.ext.imglib2.interpolators;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.interpolation.randomaccess.NLinearInterpolator2D;
+import net.imglib2.type.numeric.ARGBType;
+
+/**
+ * A {@link NLinearInterpolator2D} that performs intermediary operations with doubles, to avoid precision errors.
+ */
+class ArgbLinearInterpolator extends NLinearInterpolator2D<ARGBType> {
+
+    /**
+     * Create an instance of this class.
+     *
+     * @param randomAccessible the accessible to interpolate
+     */
+    public ArgbLinearInterpolator(RandomAccessible<ARGBType> randomAccessible) {
+        super(randomAccessible);
+    }
+
+    @Override
+    public ARGBType get()
+    {
+        fillWeights();
+
+        int pixelValue;
+        double red = 0;
+        double green = 0;
+        double blue = 0;
+        double alpha = 0;
+
+        pixelValue = target.get().get();
+        red += ARGBType.red(pixelValue) * weights[0];
+        green += ARGBType.green(pixelValue) * weights[0];
+        blue += ARGBType.blue(pixelValue) * weights[0];
+        alpha += ARGBType.alpha(pixelValue) * weights[0];
+
+        target.fwd(0);
+        pixelValue = target.get().get();
+        red += ARGBType.red(pixelValue) * weights[1];
+        green += ARGBType.green(pixelValue) * weights[1];
+        blue += ARGBType.blue(pixelValue) * weights[1];
+        alpha += ARGBType.alpha(pixelValue) * weights[1];
+
+        target.fwd(1);
+        pixelValue = target.get().get();
+        red += ARGBType.red(pixelValue) * weights[3];
+        green += ARGBType.green(pixelValue) * weights[3];
+        blue += ARGBType.blue(pixelValue) * weights[3];
+        alpha += ARGBType.alpha(pixelValue) * weights[3];
+
+        target.bck(0);
+        pixelValue = target.get().get();
+        red += ARGBType.red(pixelValue) * weights[2];
+        green += ARGBType.green(pixelValue) * weights[2];
+        blue += ARGBType.blue(pixelValue) * weights[2];
+        alpha += ARGBType.alpha(pixelValue) * weights[2];
+
+        target.bck(1);
+
+        accumulator.set(ARGBType.rgba(red, green, blue, alpha));
+
+        return accumulator;
+    }
+}

--- a/src/main/java/qupath/ext/imglib2/interpolators/LinearInterpolationFactory.java
+++ b/src/main/java/qupath/ext/imglib2/interpolators/LinearInterpolationFactory.java
@@ -1,0 +1,49 @@
+package qupath.ext.imglib2.interpolators;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.RealInterval;
+import net.imglib2.RealRandomAccess;
+import net.imglib2.interpolation.InterpolatorFactory;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * An {@link InterpolatorFactory} that implements a 2D linear interpolation.
+ * <p>
+ * This factory can only work with {@link RandomAccessible} that have 2 dimensions and the {@link ARGBType} or {@link RealType}
+ * type. If {@link #create(RandomAccessible)} is called with an invalid {@link RandomAccessible}, an {@link IllegalArgumentException}
+ * is thrown.
+ *
+ * @param <T> the type of {@link RandomAccessible} to interpolate
+ */
+public class LinearInterpolationFactory<T extends NumericType<T>> implements InterpolatorFactory<T, RandomAccessible<T>> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public RealRandomAccess<T> create(RandomAccessible randomAccessible) {
+        if (randomAccessible.numDimensions() != 2) {
+            throw new IllegalArgumentException(String.format(
+                    "The provided accessible has not 2 dimensions (found %d)",
+                    randomAccessible.numDimensions()
+            ));
+        }
+
+        Object type = randomAccessible.randomAccess().get();
+        if (type instanceof ARGBType) {
+            return (RealRandomAccess<T>) new ArgbLinearInterpolator(randomAccessible);
+        } else if (type instanceof RealType<?>) {
+            return (RealRandomAccess<T>) new RealLinearInterpolator<>(randomAccessible);
+        } else {
+            throw new IllegalArgumentException(String.format(
+                    "The type of the provided accessible %s is unexpected",
+                    type
+            ));
+        }
+    }
+
+    @Override
+    public RealRandomAccess<T> create(RandomAccessible<T> randomAccessible, RealInterval interval) {
+        return create(randomAccessible);
+    }
+}

--- a/src/main/java/qupath/ext/imglib2/interpolators/RealLinearInterpolator.java
+++ b/src/main/java/qupath/ext/imglib2/interpolators/RealLinearInterpolator.java
@@ -1,0 +1,43 @@
+package qupath.ext.imglib2.interpolators;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.interpolation.randomaccess.NLinearInterpolator2D;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * A {@link NLinearInterpolator2D} that performs intermediary operations with doubles, to avoid precision errors.
+ */
+class RealLinearInterpolator<T extends RealType<T>> extends NLinearInterpolator2D<T> {
+
+    /**
+     * Create an instance of this class.
+     *
+     * @param randomAccessible the accessible to interpolate
+     */
+    public RealLinearInterpolator(RandomAccessible<T> randomAccessible) {
+        super(randomAccessible);
+    }
+
+    @Override
+    public T get()
+    {
+        fillWeights();
+
+        double value = target.get().getRealDouble() * weights[0];
+
+        target.fwd(0);
+        value += target.get().getRealDouble() * weights[1];
+
+        target.fwd(1);
+        value += target.get().getRealDouble() * weights[3];
+
+        target.bck(0);
+        value += target.get().getRealDouble() * weights[2];
+
+        target.bck(1);
+
+        accumulator.setReal(value);
+
+        return accumulator;
+    }
+}

--- a/src/test/java/qupath/ext/imglib2/TestAccessibleScaler.java
+++ b/src/test/java/qupath/ext/imglib2/TestAccessibleScaler.java
@@ -4,6 +4,7 @@ import net.imglib2.Interval;
 import net.imglib2.Point;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.real.DoubleType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ public class TestAccessibleScaler {
     @Test
     void Check_Min_Different_From_Zero() {
         double scale = 2;
-        RandomAccessibleInterval<DoubleType> accessible = new SampleAccessible(new long[] {0, 3, 0});
+        RandomAccessibleInterval<DoubleType> accessible = new SampleDoubleAccessible(new long[] {0, 3, 0});
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> AccessibleScaler.scaleWithLinearInterpolation(accessible, scale));
     }
@@ -21,7 +22,7 @@ public class TestAccessibleScaler {
     @Test
     void Check_Negative_Scale() {
         double scale = -2;
-        RandomAccessibleInterval<DoubleType> accessible = new SampleAccessible();
+        RandomAccessibleInterval<DoubleType> accessible = new SampleDoubleAccessible();
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> AccessibleScaler.scaleWithLinearInterpolation(accessible, scale));
     }
@@ -29,20 +30,20 @@ public class TestAccessibleScaler {
     @Test
     void Check_Less_Than_Two_Dimensions() {
         double scale = 2;
-        RandomAccessibleInterval<DoubleType> accessible = new SampleAccessible(new long[] {0});
+        RandomAccessibleInterval<DoubleType> accessible = new SampleDoubleAccessible(new long[] {0});
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> AccessibleScaler.scaleWithLinearInterpolation(accessible, scale));
     }
 
     @Test
-    void Check_Linear_Interpolation_Scale_With_2_by_4_Array() {
-        RandomAccessibleInterval<DoubleType> accessible = new SampleAccessible(new double[][] {
+    void Check_Linear_Interpolation_Scale_With_2_by_4_Double_Array() {
+        RandomAccessibleInterval<DoubleType> accessible = new SampleDoubleAccessible(new double[][] {
                 new double[] {0.80, 0.97, 0.40, 0.99},
                 new double[] {0.95, 0.22, 0.63, 0.25}
         });
         double scale = 0.5;
         double[][] expectedPixels = new double[][] {
-                new double[] {0.735, 0.5675}
+                new double[] {(0.80 + 0.97 + 0.95 + 0.22) / 4, (0.40 + 0.99 + 0.63 + 0.25) / 4}
         };
 
         RandomAccessibleInterval<DoubleType> scaledAccessible = AccessibleScaler.scaleWithLinearInterpolation(accessible, scale);
@@ -51,13 +52,13 @@ public class TestAccessibleScaler {
     }
 
     @Test
-    void Check_Linear_Interpolation_Scale_With_1_by_3_Array() {
-        RandomAccessibleInterval<DoubleType> accessible = new SampleAccessible(new double[][] {
+    void Check_Linear_Interpolation_Scale_With_1_by_3_Double_Array() {
+        RandomAccessibleInterval<DoubleType> accessible = new SampleDoubleAccessible(new double[][] {
                 new double[] {0.26, 0.66, 0.34}
         });
         double scale = 0.5;
         double[][] expectedPixels = new double[][] {
-                new double[] {0.46}
+                new double[] {(0.26 + 0.66) / 2}
         };
 
         RandomAccessibleInterval<DoubleType> scaledAccessible = AccessibleScaler.scaleWithLinearInterpolation(accessible, scale);
@@ -66,8 +67,8 @@ public class TestAccessibleScaler {
     }
 
     @Test
-    void Check_Linear_Interpolation_Interpolation_Scale_With_5_by_5_Array() {
-        RandomAccessibleInterval<DoubleType> accessible = new SampleAccessible(new double[][] {
+    void Check_Linear_Interpolation_Interpolation_Scale_With_5_by_5_Double_Array() {
+        RandomAccessibleInterval<DoubleType> accessible = new SampleDoubleAccessible(new double[][] {
                 new double[] {0.80, 0.72, 0.48, 0.27, 0.68},
                 new double[] {0.41, 0.21, 0.60, 0.47, 0.86},
                 new double[] {0.94, 0.32, 0.55, 0.22, 0.46},
@@ -76,8 +77,8 @@ public class TestAccessibleScaler {
         });
         double scale = 0.5;
         double[][] expectedPixels = new double[][] {
-                new double[] {0.535, 0.455},
-                new double[] {0.63, 0.4825}
+                new double[] {(0.80 + 0.72 + 0.41 + 0.21) / 4, (0.48 + 0.27 + 0.60 + 0.47) / 4},
+                new double[] {(0.94 + 0.32 + 0.43 + 0.83) / 4, (0.55 + 0.22 + 0.49 + 0.67) / 4}
         };
 
         RandomAccessibleInterval<DoubleType> scaledAccessible = AccessibleScaler.scaleWithLinearInterpolation(accessible, scale);
@@ -86,8 +87,27 @@ public class TestAccessibleScaler {
     }
 
     @Test
+    void Check_Linear_Interpolation_Scale_With_2_by_4_Argb_Array() {
+        RandomAccessibleInterval<ARGBType> accessible = new SampleArgbAccessible(new int[][] {
+                new int[] {ARGBType.rgba(82, 79, 61, 46), ARGBType.rgba(67, 94, 89, 62), ARGBType.rgba(13, 33, 3, 42), ARGBType.rgba(92, 41, 35, 54)},
+                new int[] {ARGBType.rgba(32, 64, 90, 99), ARGBType.rgba(58, 55, 73, 84), ARGBType.rgba(81, 63, 45, 11), ARGBType.rgba(22, 24, 37, 34)}
+        });
+        double scale = 0.5;
+        int[][] expectedPixels = new int[][] {
+                new int[] {
+                        ARGBType.rgba(Math.round((82 + 67 + 32 + 58) / 4.), Math.round((79 + 94 + 64 + 55) / 4.), Math.round((61 + 89 + 90 + 73) / 4.), Math.round((46 + 62 + 99 + 84) / 4.)),
+                        ARGBType.rgba(Math.round((13 + 92 + 22 + 81) / 4.), Math.round((33 + 41 + 24 + 63) / 4.), Math.round((3 + 35 + 37 + 45) / 4.), Math.round((42 + 54 + 34 + 11) / 4.))
+                }
+        };
+
+        RandomAccessibleInterval<ARGBType> scaledAccessible = AccessibleScaler.scaleWithLinearInterpolation(accessible, scale);
+
+        Utils.assertArgbRandomAccessibleEquals(scaledAccessible, expectedPixels);
+    }
+
+    @Test
     void Check_Nearest_Neighbor_Interpolation_Scale_With_2_by_4_Array() {
-        RandomAccessibleInterval<DoubleType> accessible = new SampleAccessible(new double[][] {
+        RandomAccessibleInterval<DoubleType> accessible = new SampleDoubleAccessible(new double[][] {
                 new double[] {0.80, 0.97, 0.40, 0.99},
                 new double[] {0.95, 0.22, 0.63, 0.25}
         });
@@ -103,7 +123,7 @@ public class TestAccessibleScaler {
 
     @Test
     void Check_Nearest_Neighbor_Interpolation_Scale_With_1_by_3_Array() {
-        RandomAccessibleInterval<DoubleType> accessible = new SampleAccessible(new double[][] {
+        RandomAccessibleInterval<DoubleType> accessible = new SampleDoubleAccessible(new double[][] {
                 new double[] {0.26, 0.66, 0.34}
         });
         double scale = 0.5;
@@ -118,7 +138,7 @@ public class TestAccessibleScaler {
 
     @Test
     void Check_Nearest_Neighbor_Interpolation_Scale_With_5_by_5_Array() {
-        RandomAccessibleInterval<DoubleType> accessible = new SampleAccessible(new double[][] {
+        RandomAccessibleInterval<DoubleType> accessible = new SampleDoubleAccessible(new double[][] {
                 new double[] {0.80, 0.72, 0.48, 0.27, 0.68},
                 new double[] {0.41, 0.21, 0.60, 0.47, 0.86},
                 new double[] {0.94, 0.32, 0.55, 0.22, 0.46},
@@ -136,27 +156,27 @@ public class TestAccessibleScaler {
         Utils.assertRandomAccessibleEquals(scaledAccessible, expectedPixels);
     }
 
-    private static class SampleAccessible implements RandomAccessibleInterval<DoubleType> {
+    private static class SampleDoubleAccessible implements RandomAccessibleInterval<DoubleType> {
 
         private final long[] min;
         private final long[] max;
         private final double[][] values;
 
-        public SampleAccessible() {
+        public SampleDoubleAccessible() {
             this(new long[] {0, 0});
         }
 
-        public SampleAccessible(double[][] values) {
+        public SampleDoubleAccessible(double[][] values) {
             this(new long[] {0, 0}, values);
         }
 
-        public SampleAccessible(long[] min) {
+        public SampleDoubleAccessible(long[] min) {
             this(min, new double[][] {
                     new double[] {}
             });
         }
 
-        private SampleAccessible(long[] min, double[][] values) {
+        private SampleDoubleAccessible(long[] min, double[][] values) {
             this.min = min;
             this.max = new long[] {values.length - 1, values[0].length - 1};
             this.values = values;
@@ -174,7 +194,7 @@ public class TestAccessibleScaler {
 
         @Override
         public RandomAccess<DoubleType> randomAccess() {
-            return new SampleAccess(values);
+            return new SampleDoubleAccess(values);
         }
 
         @Override
@@ -188,12 +208,12 @@ public class TestAccessibleScaler {
         }
     }
 
-    private static class SampleAccess extends Point implements RandomAccess<DoubleType> {
+    private static class SampleDoubleAccess extends Point implements RandomAccess<DoubleType> {
 
         private final DoubleType value = new DoubleType();
         private final double[][] values;
 
-        public SampleAccess(double[][] values) {
+        public SampleDoubleAccess(double[][] values) {
             super(2);
 
             this.values = values;
@@ -207,7 +227,67 @@ public class TestAccessibleScaler {
 
         @Override
         public RandomAccess<DoubleType> copy() {
-            return new SampleAccess(values);
+            return new SampleDoubleAccess(values);
+        }
+    }
+
+    private static class SampleArgbAccessible implements RandomAccessibleInterval<ARGBType> {
+
+        private final long[] min = new long[] {0, 0};
+        private final long[] max;
+        private final int[][] values;
+
+        public SampleArgbAccessible(int[][] values) {
+            this.max = new long[] {values.length - 1, values[0].length - 1};
+            this.values = values;
+        }
+
+        @Override
+        public long min(int d) {
+            return min[d];
+        }
+
+        @Override
+        public long max(int d) {
+            return max[d];
+        }
+
+        @Override
+        public RandomAccess<ARGBType> randomAccess() {
+            return new SampleArgbAccess(values);
+        }
+
+        @Override
+        public RandomAccess<ARGBType> randomAccess(Interval interval) {
+            return randomAccess();
+        }
+
+        @Override
+        public int numDimensions() {
+            return min.length;
+        }
+    }
+
+    private static class SampleArgbAccess extends Point implements RandomAccess<ARGBType> {
+
+        private final ARGBType value = new ARGBType();
+        private final int[][] values;
+
+        public SampleArgbAccess(int[][] values) {
+            super(2);
+
+            this.values = values;
+        }
+
+        @Override
+        public ARGBType get() {
+            value.set(values[(int) position[0]][(int) position[1]]);
+            return value;
+        }
+
+        @Override
+        public RandomAccess<ARGBType> copy() {
+            return new SampleArgbAccess(values);
         }
     }
 }

--- a/src/test/java/qupath/ext/imglib2/Utils.java
+++ b/src/test/java/qupath/ext/imglib2/Utils.java
@@ -161,6 +161,27 @@ public class Utils {
         }
     }
 
+    public static void assertArgbRandomAccessibleEquals(RandomAccessibleInterval<ARGBType> accessible, int[][] expectedPixels) {
+        Assertions.assertEquals(expectedPixels.length, accessible.dimension(0));
+        Assertions.assertEquals(expectedPixels[0].length, accessible.dimension(1));
+
+        int[] position = new int[accessible.numDimensions()];
+        Cursor<ARGBType> cursor = accessible.localizingCursor();
+
+        while (cursor.hasNext()) {
+            ARGBType pixel = cursor.next();
+            cursor.localize(position);
+            int x = position[1];
+            int y = position[0];
+
+            Assertions.assertEquals(
+                    expectedPixels[y][x],
+                    pixel.get(),
+                    0.0000000001        // to avoid rounding errors
+            );
+        }
+    }
+
     public static void assertBufferedImagesEqual(BufferedImage expectedImage, BufferedImage actualImage, double delta) {
         Assertions.assertEquals(expectedImage.getWidth(), actualImage.getWidth());
         Assertions.assertEquals(expectedImage.getHeight(), actualImage.getHeight());


### PR DESCRIPTION
Considering a point `p` and its four closest points `p1`, `p2`, `p3`, and `p4`, linear interpolation is implemented with the following formula:

```
p = t1*p1 + t2*p2 + t3*p3 + t4*p4
```

with the `ti` between 0 and 1 representing the distance between `p` and `pi`.

With integer images, the ImgLib2 `NLinearInterpolatorFactory` computes something like this:

```
p = round(t1*p1) + round(t2*p2) + round(t3*p3) + round(t4*p4)
```

This is an issue, because there is a high loss of precision. For example, with an image containing only pixels with value 20, this interpolation can create pixels with values 19 or 21.

This PR provides a custom implementation of the linear interpolation, which computes something like this:

```
p = round(t1*p1 + t2*p2 + t3*p3 + t4*p4)
```

There's still a precision loss, but less than before (and it's unavoidable).