### PR TITLE
Make all accesses implement ArrayDataAccess

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.github.qupath"
-version = "0.1.1"
+version = "0.1.2"
 
 repositories {
     mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ pluginManagement {
 rootProject.name = "qupath-imglib2"
 
 // Used for version catalogs (including Java compatibility)
-val qupathVersion = "0.6.0"
+val qupathVersion = "0.7.0"
 val sciJavaVersion = "43.0.0"
 
 dependencyResolutionManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ rootProject.name = "qupath-imglib2"
 
 // Used for version catalogs (including Java compatibility)
 val qupathVersion = "0.7.0"
-val sciJavaVersion = "43.0.0"
+val sciJavaVersion = "44.0.0"
 
 dependencyResolutionManagement {
 
@@ -28,8 +28,8 @@ dependencyResolutionManagement {
     }
 
     repositories {
-        maven("https://maven.scijava.org/content/groups/public/")
         mavenCentral()
+        maven("https://maven.scijava.org/content/groups/public/")
     }
 
 }

--- a/src/main/java/qupath/ext/imglib2/accesses/AccessTools.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/AccessTools.java
@@ -45,19 +45,16 @@ class AccessTools {
      * @return the size of the provided data buffer in bytes
      */
     public static int getSizeOfDataBufferInBytes(DataBuffer dataBuffer) {
-        int bytesPerPixel;
-        if (dataBuffer instanceof DataBufferByte) {
-            bytesPerPixel = 1;
-        } else if (dataBuffer instanceof DataBufferShort || dataBuffer instanceof DataBufferUShort) {
-            bytesPerPixel = 2;
-        } else if (dataBuffer instanceof DataBufferInt || dataBuffer instanceof DataBufferFloat) {
-            bytesPerPixel = 4;
-        } else  if (dataBuffer instanceof DataBufferDouble) {
-            bytesPerPixel = 8;
-        } else {
-            logger.warn("Unexpected data buffer {}. Considering each element of it takes 1 byte", dataBuffer);
-            bytesPerPixel = 1;
-        }
+        int bytesPerPixel = switch (dataBuffer) {
+            case DataBufferByte _ -> 1;
+            case DataBufferShort _, DataBufferUShort _ -> 2;
+            case DataBufferInt _, DataBufferFloat _ -> 4;
+            case DataBufferDouble _ -> 8;
+            default -> {
+                logger.warn("Unexpected data buffer {}. Considering each element of it takes 1 byte", dataBuffer);
+                yield 1;
+            }
+        };
 
         return bytesPerPixel * dataBuffer.getSize() * dataBuffer.getNumBanks();
     }

--- a/src/main/java/qupath/ext/imglib2/accesses/ArgbBufferedImageAccess.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/ArgbBufferedImageAccess.java
@@ -1,6 +1,6 @@
 package qupath.ext.imglib2.accesses;
 
-import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.img.basictypeaccess.array.IntArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import qupath.ext.imglib2.SizableDataAccess;
 import qupath.lib.common.ColorTools;
@@ -8,27 +8,22 @@ import qupath.lib.common.ColorTools;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
+import java.awt.image.Raster;
 import java.awt.image.SinglePixelPackedSampleModel;
 
 /**
- * An {@link IntAccess} whose elements are computed from an (A)RGB {@link BufferedImage}.
+ * An {@link IntArray} whose elements are computed from an (A)RGB {@link BufferedImage}.
  * <p>
  * If the alpha component is not provided (e.g. if the {@link BufferedImage} has the {@link BufferedImage#TYPE_INT_RGB} type),
  * then the alpha component of each pixel is considered to be 255.
  * <p>
- * This {@link IntAccess} is immutable; any attempt to changes its values will result in a
+ * This {@link IntArray} is immutable; any attempt to changes its values will result in a
  * {@link UnsupportedOperationException}.
  * <p>
  * This data access is marked as volatile but always contain valid data.
  */
-public class ArgbBufferedImageAccess implements IntAccess, SizableDataAccess, VolatileAccess {
+public class ArgbBufferedImageAccess extends IntArray implements SizableDataAccess, VolatileAccess {
 
-    private final BufferedImage image;
-    private final DataBuffer dataBuffer;
-    private final int width;
-    private final int planeSize;
-    private final boolean canUseDataBuffer;
-    private final boolean alphaProvided;
     private final int size;
 
     /**
@@ -38,39 +33,45 @@ public class ArgbBufferedImageAccess implements IntAccess, SizableDataAccess, Vo
      * @throws NullPointerException if the provided image is null
      */
     public ArgbBufferedImageAccess(BufferedImage image) {
-        this.image = image;
-        this.dataBuffer = this.image.getRaster().getDataBuffer();
+        super(createArrayFromImage(image));
 
-        this.width = this.image.getWidth();
-        this.planeSize = width * this.image.getHeight();
-
-        this.canUseDataBuffer = image.getRaster().getDataBuffer() instanceof DataBufferInt &&
-                image.getRaster().getSampleModel() instanceof SinglePixelPackedSampleModel;
-        this.alphaProvided = image.getType() == BufferedImage.TYPE_INT_ARGB;
-
-        this.size = AccessTools.getSizeOfDataBufferInBytes(this.dataBuffer);
+        this.size = AccessTools.getSizeOfDataBufferInBytes(image.getRaster().getDataBuffer());
     }
 
-    @Override
-    public int getValue(int index) {
-        int xyIndex = index % planeSize;
+    private static int[] createArrayFromImage(BufferedImage image) {
+        Raster raster = image.getRaster();
+        int width = raster.getWidth();
+        int height = raster.getHeight();
+        int planeSize = width * height;
 
-        if (canUseDataBuffer) {
-            int pixel = dataBuffer.getElem(0, xyIndex);
+        int[] array = new int[planeSize];
+        if (raster.getSampleModel() instanceof SinglePixelPackedSampleModel && raster.getDataBuffer() instanceof DataBufferInt) {
+            DataBuffer dataBuffer = raster.getDataBuffer();
+            boolean alphaProvided = image.getType() == BufferedImage.TYPE_INT_ARGB;
 
-            if (alphaProvided) {
-                return pixel;
-            } else {
-                return ColorTools.packARGB(
-                        255,
-                        ColorTools.red(pixel),
-                        ColorTools.green(pixel),
-                        ColorTools.blue(pixel)
-                );
+            for (int i=0; i<planeSize; i++) {
+                int pixel = dataBuffer.getElem(0, i);
+
+                if (alphaProvided) {
+                    array[i] = pixel;
+                } else {
+                    array[i] = ColorTools.packARGB(
+                            255,
+                            ColorTools.red(pixel),
+                            ColorTools.green(pixel),
+                            ColorTools.blue(pixel)
+                    );
+                }
             }
         } else {
-            return image.getRGB(xyIndex % width, xyIndex / width);
+            for (int y=0; y<height; y++) {
+                for (int x=0; x<width; x++) {
+                    array[x + y * width] = image.getRGB(x, y);
+                }
+            }
         }
+
+        return array;
     }
 
     @Override

--- a/src/main/java/qupath/ext/imglib2/accesses/ByteBufferedImageAccess.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/ByteBufferedImageAccess.java
@@ -1,6 +1,6 @@
 package qupath.ext.imglib2.accesses;
 
-import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import qupath.ext.imglib2.SizableDataAccess;
 import qupath.lib.common.ColorTools;
@@ -8,25 +8,21 @@ import qupath.lib.common.ColorTools;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
+import java.awt.image.Raster;
 import java.awt.image.SinglePixelPackedSampleModel;
 
 /**
- * An {@link ByteAccess} whose elements are computed from an RGB {@link BufferedImage}.
+ * An {@link ByteArray} whose elements are computed from an RGB {@link BufferedImage}.
  * <p>
  * The alpha component is not taken into account.
  * <p>
- * This {@link ByteAccess} is immutable; any attempt to changes its values will result in a
+ * This {@link ByteArray} is immutable; any attempt to changes its values will result in a
  * {@link UnsupportedOperationException}.
  * <p>
  * This data access is marked as volatile but always contain valid data.
  */
-public class ByteBufferedImageAccess implements ByteAccess, SizableDataAccess, VolatileAccess {
+public class ByteBufferedImageAccess extends ByteArray implements SizableDataAccess, VolatileAccess {
 
-    private final BufferedImage image;
-    private final DataBuffer dataBuffer;
-    private final int width;
-    private final int planeSize;
-    private final boolean canUseDataBuffer;
     private final int size;
 
     /**
@@ -36,33 +32,9 @@ public class ByteBufferedImageAccess implements ByteAccess, SizableDataAccess, V
      * @throws NullPointerException if the provided image is null
      */
     public ByteBufferedImageAccess(BufferedImage image) {
-        this.image = image;
-        this.dataBuffer = this.image.getRaster().getDataBuffer();
+        super(createArrayFromImage(image));
 
-        this.width = this.image.getWidth();
-        this.planeSize = width * this.image.getHeight();
-
-        this.canUseDataBuffer = image.getRaster().getDataBuffer() instanceof DataBufferInt &&
-                image.getRaster().getSampleModel() instanceof SinglePixelPackedSampleModel;
-
-        this.size = AccessTools.getSizeOfDataBufferInBytes(this.dataBuffer);
-    }
-
-    @Override
-    public byte getValue(int index) {
-        int channel = index / planeSize;
-        int xyIndex = index % planeSize;
-
-        int pixel = canUseDataBuffer ?
-                dataBuffer.getElem(0, xyIndex) :
-                image.getRGB(xyIndex % width, xyIndex / width);
-
-        return switch (channel) {
-            case 0 -> (byte) ColorTools.red(pixel);
-            case 1 -> (byte) ColorTools.green(pixel);
-            case 2 -> (byte) ColorTools.blue(pixel);
-            default -> throw new IllegalArgumentException(String.format("The provided index %d is out of bounds", index));
-        };
+        this.size = AccessTools.getSizeOfDataBufferInBytes(image.getRaster().getDataBuffer());
     }
 
     @Override
@@ -78,5 +50,48 @@ public class ByteBufferedImageAccess implements ByteAccess, SizableDataAccess, V
     @Override
     public boolean isValid() {
         return true;
+    }
+
+    private static byte[] createArrayFromImage(BufferedImage image) {
+        Raster raster = image.getRaster();
+        int width = raster.getWidth();
+        int height = raster.getHeight();
+        int planeSize = width * height;
+        int numBands = 3;
+
+        byte[] array = new byte[planeSize * numBands];
+        if (raster.getSampleModel() instanceof SinglePixelPackedSampleModel && raster.getDataBuffer() instanceof DataBufferInt) {
+            DataBuffer dataBuffer = raster.getDataBuffer();
+
+            for (int b=0; b<numBands; b++) {
+                for (int i=0; i<planeSize; i++) {
+                    int pixel = dataBuffer.getElem(0, i);
+
+                    array[i + b * planeSize] = (byte) switch (b) {
+                        case 0 -> ColorTools.red(pixel);
+                        case 1 -> ColorTools.green(pixel);
+                        case 2 -> ColorTools.blue(pixel);
+                        default -> throw new IllegalArgumentException(String.format("The provided channel %d is out of bounds", b));
+                    };
+                }
+            }
+        } else {
+            for (int b=0; b<numBands; b++) {
+                for (int y=0; y<height; y++) {
+                    for (int x=0; x<width; x++) {
+                        int pixel = image.getRGB(x, y);
+
+                        array[x + y * width + b * planeSize] = (byte) switch (b) {
+                            case 0 -> ColorTools.red(pixel);
+                            case 1 -> ColorTools.green(pixel);
+                            case 2 -> ColorTools.blue(pixel);
+                            default -> throw new IllegalArgumentException(String.format("The provided channel %d is out of bounds", b));
+                        };
+                    }
+                }
+            }
+        }
+
+        return array;
     }
 }

--- a/src/main/java/qupath/ext/imglib2/accesses/ByteRasterAccess.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/ByteRasterAccess.java
@@ -1,6 +1,6 @@
 package qupath.ext.imglib2.accesses;
 
-import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import qupath.ext.imglib2.SizableDataAccess;
 
@@ -9,20 +9,15 @@ import java.awt.image.DataBufferByte;
 import java.awt.image.Raster;
 
 /**
- * A {@link ByteAccess} whose elements are computed from a {@link Raster}.
+ * A {@link ByteArray} whose elements are computed from a {@link Raster}.
  * <p>
- * This {@link ByteAccess} is immutable; any attempt to changes its values will result in a
+ * This {@link ByteArray} is immutable; any attempt to changes its values will result in a
  * {@link UnsupportedOperationException}.
  * <p>
  * This data access is marked as volatile but always contain valid data.
  */
-public class ByteRasterAccess implements ByteAccess, SizableDataAccess, VolatileAccess {
+public class ByteRasterAccess extends ByteArray implements SizableDataAccess, VolatileAccess {
 
-    private final Raster raster;
-    private final DataBuffer dataBuffer;
-    private final int width;
-    private final int planeSize;
-    private final boolean canUseDataBuffer;
     private final int size;
 
     /**
@@ -32,28 +27,9 @@ public class ByteRasterAccess implements ByteAccess, SizableDataAccess, Volatile
      * @throws NullPointerException if the provided image is null
      */
     public ByteRasterAccess(Raster raster) {
-        this.raster = raster;
-        this.dataBuffer = this.raster.getDataBuffer();
+        super(createArrayFromRaster(raster));
 
-        this.width = this.raster.getWidth();
-        this.planeSize = width * this.raster.getHeight();
-
-        this.canUseDataBuffer = this.dataBuffer instanceof DataBufferByte &&
-                AccessTools.isSampleModelDirectlyUsable(this.raster);
-
-        this.size = AccessTools.getSizeOfDataBufferInBytes(this.dataBuffer);
-    }
-
-    @Override
-    public byte getValue(int index) {
-        int b = index / planeSize;
-        int xyIndex = index % planeSize;
-
-        if (canUseDataBuffer) {
-            return (byte) dataBuffer.getElem(b, xyIndex);
-        } else {
-            return (byte) raster.getSample(xyIndex % width, xyIndex / width, b);
-        }
+        this.size = AccessTools.getSizeOfDataBufferInBytes(raster.getDataBuffer());
     }
 
     @Override
@@ -69,5 +45,33 @@ public class ByteRasterAccess implements ByteAccess, SizableDataAccess, Volatile
     @Override
     public boolean isValid() {
         return true;
+    }
+
+    private static byte[] createArrayFromRaster(Raster raster) {
+        int width = raster.getWidth();
+        int height = raster.getHeight();
+        int planeSize = width * height;
+        int numBands = raster.getNumBands();
+
+        byte[] array = new byte[planeSize * numBands];
+        if (AccessTools.isSampleModelDirectlyUsable(raster) && raster.getDataBuffer() instanceof DataBufferByte) {
+            DataBuffer dataBuffer = raster.getDataBuffer();
+
+            for (int b=0; b<numBands; b++) {
+                for (int i=0; i<planeSize; i++) {
+                    array[i + b * planeSize] = (byte) dataBuffer.getElem(b, i);
+                }
+            }
+        } else {
+            for (int b=0; b<numBands; b++) {
+                for (int y=0; y<height; y++) {
+                    for (int x=0; x<width; x++) {
+                        array[x + y * width + b * planeSize] = (byte) raster.getSample(x, y, b);
+                    }
+                }
+            }
+        }
+
+        return array;
     }
 }

--- a/src/main/java/qupath/ext/imglib2/accesses/DoubleRasterAccess.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/DoubleRasterAccess.java
@@ -1,6 +1,6 @@
 package qupath.ext.imglib2.accesses;
 
-import net.imglib2.img.basictypeaccess.DoubleAccess;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import qupath.ext.imglib2.SizableDataAccess;
 
@@ -9,20 +9,15 @@ import java.awt.image.DataBufferDouble;
 import java.awt.image.Raster;
 
 /**
- * A {@link DoubleAccess} whose elements are computed from a {@link Raster}.
+ * A {@link DoubleArray} whose elements are computed from a {@link Raster}.
  * <p>
- * This {@link DoubleAccess} is immutable; any attempt to changes its values will result in a
+ * This {@link DoubleArray} is immutable; any attempt to changes its values will result in a
  * {@link UnsupportedOperationException}.
  * <p>
  * This data access is marked as volatile but always contain valid data.
  */
-public class DoubleRasterAccess implements DoubleAccess, SizableDataAccess, VolatileAccess {
+public class DoubleRasterAccess extends DoubleArray implements SizableDataAccess, VolatileAccess {
 
-    private final Raster raster;
-    private final DataBuffer dataBuffer;
-    private final int width;
-    private final int planeSize;
-    private final boolean canUseDataBuffer;
     private final int size;
 
     /**
@@ -32,28 +27,9 @@ public class DoubleRasterAccess implements DoubleAccess, SizableDataAccess, Vola
      * @throws NullPointerException if the provided image is null
      */
     public DoubleRasterAccess(Raster raster) {
-        this.raster = raster;
-        this.dataBuffer = this.raster.getDataBuffer();
+        super(createArrayFromRaster(raster));
 
-        this.width = this.raster.getWidth();
-        this.planeSize = width * this.raster.getHeight();
-        
-        this.canUseDataBuffer = this.dataBuffer instanceof DataBufferDouble &&
-                AccessTools.isSampleModelDirectlyUsable(this.raster);
-
-        this.size = AccessTools.getSizeOfDataBufferInBytes(this.dataBuffer);
-    }
-
-    @Override
-    public double getValue(int index) {
-        int b = index / planeSize;
-        int xyIndex = index % planeSize;
-
-        if (canUseDataBuffer) {
-            return dataBuffer.getElemDouble(b, xyIndex);
-        } else {
-            return raster.getSampleDouble(xyIndex % width, xyIndex / width, b);
-        }
+        this.size = AccessTools.getSizeOfDataBufferInBytes(raster.getDataBuffer());
     }
 
     @Override
@@ -69,5 +45,33 @@ public class DoubleRasterAccess implements DoubleAccess, SizableDataAccess, Vola
     @Override
     public boolean isValid() {
         return true;
+    }
+
+    private static double[] createArrayFromRaster(Raster raster) {
+        int width = raster.getWidth();
+        int height = raster.getHeight();
+        int planeSize = width * height;
+        int numBands = raster.getNumBands();
+
+        double[] array = new double[planeSize * numBands];
+        if (AccessTools.isSampleModelDirectlyUsable(raster) && raster.getDataBuffer() instanceof DataBufferDouble) {
+            DataBuffer dataBuffer = raster.getDataBuffer();
+
+            for (int b=0; b<numBands; b++) {
+                for (int i=0; i<planeSize; i++) {
+                    array[i + b * planeSize] = dataBuffer.getElemDouble(b, i);
+                }
+            }
+        } else {
+            for (int b=0; b<numBands; b++) {
+                for (int y=0; y<height; y++) {
+                    for (int x=0; x<width; x++) {
+                        array[x + y * width + b * planeSize] = raster.getSampleDouble(x, y, b);
+                    }
+                }
+            }
+        }
+
+        return array;
     }
 }

--- a/src/main/java/qupath/ext/imglib2/accesses/FloatRasterAccess.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/FloatRasterAccess.java
@@ -1,6 +1,6 @@
 package qupath.ext.imglib2.accesses;
 
-import net.imglib2.img.basictypeaccess.FloatAccess;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import qupath.ext.imglib2.SizableDataAccess;
 
@@ -9,20 +9,15 @@ import java.awt.image.DataBufferFloat;
 import java.awt.image.Raster;
 
 /**
- * A {@link FloatAccess} whose elements are computed from a {@link Raster}.
+ * A {@link FloatArray} whose elements are computed from a {@link Raster}.
  * <p>
- * This {@link FloatAccess} is immutable; any attempt to changes its values will result in a
+ * This {@link FloatArray} is immutable; any attempt to changes its values will result in a
  * {@link UnsupportedOperationException}.
  * <p>
  * This data access is marked as volatile but always contain valid data.
  */
-public class FloatRasterAccess implements FloatAccess, SizableDataAccess, VolatileAccess {
+public class FloatRasterAccess extends FloatArray implements SizableDataAccess, VolatileAccess {
 
-    private final Raster raster;
-    private final DataBuffer dataBuffer;
-    private final int width;
-    private final int planeSize;
-    private final boolean canUseDataBuffer;
     private final int size;
 
     /**
@@ -32,28 +27,9 @@ public class FloatRasterAccess implements FloatAccess, SizableDataAccess, Volati
      * @throws NullPointerException if the provided image is null
      */
     public FloatRasterAccess(Raster raster) {
-        this.raster = raster;
-        this.dataBuffer = this.raster.getDataBuffer();
+        super(createArrayFromRaster(raster));
 
-        this.width = this.raster.getWidth();
-        this.planeSize = width * this.raster.getHeight();
-
-        this.canUseDataBuffer = this.dataBuffer instanceof DataBufferFloat &&
-                AccessTools.isSampleModelDirectlyUsable(this.raster);
-
-        this.size = AccessTools.getSizeOfDataBufferInBytes(this.dataBuffer);
-    }
-
-    @Override
-    public float getValue(int index) {
-        int b = index / planeSize;
-        int xyIndex = index % planeSize;
-
-        if (canUseDataBuffer) {
-            return dataBuffer.getElemFloat(b, xyIndex);
-        } else {
-            return raster.getSampleFloat(xyIndex % width, xyIndex / width, b);
-        }
+        this.size = AccessTools.getSizeOfDataBufferInBytes(raster.getDataBuffer());
     }
 
     @Override
@@ -69,5 +45,33 @@ public class FloatRasterAccess implements FloatAccess, SizableDataAccess, Volati
     @Override
     public boolean isValid() {
         return true;
+    }
+
+    private static float[] createArrayFromRaster(Raster raster) {
+        int width = raster.getWidth();
+        int height = raster.getHeight();
+        int planeSize = width * height;
+        int numBands = raster.getNumBands();
+
+        float[] array = new float[planeSize * numBands];
+        if (AccessTools.isSampleModelDirectlyUsable(raster) && raster.getDataBuffer() instanceof DataBufferFloat) {
+            DataBuffer dataBuffer = raster.getDataBuffer();
+
+            for (int b=0; b<numBands; b++) {
+                for (int i=0; i<planeSize; i++) {
+                    array[i + b * planeSize] = dataBuffer.getElemFloat(b, i);
+                }
+            }
+        } else {
+            for (int b=0; b<numBands; b++) {
+                for (int y=0; y<height; y++) {
+                    for (int x=0; x<width; x++) {
+                        array[x + y * width + b * planeSize] = raster.getSampleFloat(x, y, b);
+                    }
+                }
+            }
+        }
+
+        return array;
     }
 }

--- a/src/main/java/qupath/ext/imglib2/accesses/IntRasterAccess.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/IntRasterAccess.java
@@ -1,6 +1,6 @@
 package qupath.ext.imglib2.accesses;
 
-import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.img.basictypeaccess.array.IntArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import qupath.ext.imglib2.SizableDataAccess;
 
@@ -9,51 +9,27 @@ import java.awt.image.DataBufferInt;
 import java.awt.image.Raster;
 
 /**
- * An {@link IntAccess} whose elements are computed from a {@link Raster}.
+ * An {@link IntArray} whose elements are computed from a {@link Raster}.
  * <p>
- * This {@link IntAccess} is immutable; any attempt to changes its values will result in a
+ * This {@link IntArray} is immutable; any attempt to changes its values will result in a
  * {@link UnsupportedOperationException}.
  * <p>
  * This data access is marked as volatile but always contain valid data.
  */
-public class IntRasterAccess implements IntAccess, SizableDataAccess, VolatileAccess {
+public class IntRasterAccess extends IntArray implements SizableDataAccess, VolatileAccess {
 
-    private final Raster raster;
-    private final DataBuffer dataBuffer;
-    private final int width;
-    private final int planeSize;
-    private final boolean canUseDataBuffer;
     private final int size;
 
     /**
      * Create the int raster access.
      *
      * @param raster the raster containing the values to return. Its pixels are expected to be stored in the int format
-     * @throws NullPointerException if the provided image is null
+     * @throws NullPointerException if the provided raster is null
      */
     public IntRasterAccess(Raster raster) {
-        this.raster = raster;
-        this.dataBuffer = this.raster.getDataBuffer();
+        super(createArrayFromRaster(raster));
 
-        this.width = this.raster.getWidth();
-        this.planeSize = width * this.raster.getHeight();
-
-        this.canUseDataBuffer = this.dataBuffer instanceof DataBufferInt &&
-                AccessTools.isSampleModelDirectlyUsable(this.raster);
-
-        this.size = AccessTools.getSizeOfDataBufferInBytes(this.dataBuffer);
-    }
-
-    @Override
-    public int getValue(int index) {
-        int b = index / planeSize;
-        int xyIndex = index % planeSize;
-
-        if (canUseDataBuffer) {
-            return dataBuffer.getElem(b, xyIndex);
-        } else {
-            return raster.getSample(xyIndex % width, xyIndex / width, b);
-        }
+        this.size = AccessTools.getSizeOfDataBufferInBytes(raster.getDataBuffer());
     }
 
     @Override
@@ -69,5 +45,33 @@ public class IntRasterAccess implements IntAccess, SizableDataAccess, VolatileAc
     @Override
     public boolean isValid() {
         return true;
+    }
+
+    private static int[] createArrayFromRaster(Raster raster) {
+        int width = raster.getWidth();
+        int height = raster.getHeight();
+        int planeSize = width * height;
+        int numBands = raster.getNumBands();
+
+        int[] array = new int[planeSize * numBands];
+        if (AccessTools.isSampleModelDirectlyUsable(raster) && raster.getDataBuffer() instanceof DataBufferInt) {
+            DataBuffer dataBuffer = raster.getDataBuffer();
+
+            for (int b=0; b<numBands; b++) {
+                for (int i=0; i<planeSize; i++) {
+                    array[i + b * planeSize] = dataBuffer.getElem(b, i);
+                }
+            }
+        } else {
+            for (int b=0; b<numBands; b++) {
+                for (int y=0; y<height; y++) {
+                    for (int x=0; x<width; x++) {
+                        array[x + y * width + b * planeSize] = raster.getSample(x, y, b);
+                    }
+                }
+            }
+        }
+
+        return array;
     }
 }

--- a/src/main/java/qupath/ext/imglib2/accesses/ShortRasterAccess.java
+++ b/src/main/java/qupath/ext/imglib2/accesses/ShortRasterAccess.java
@@ -1,6 +1,6 @@
 package qupath.ext.imglib2.accesses;
 
-import net.imglib2.img.basictypeaccess.ShortAccess;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import qupath.ext.imglib2.SizableDataAccess;
 
@@ -10,20 +10,15 @@ import java.awt.image.DataBufferUShort;
 import java.awt.image.Raster;
 
 /**
- * A {@link ShortAccess} whose elements are computed from a {@link Raster}.
+ * A {@link ShortArray} whose elements are computed from a {@link Raster}.
  * <p>
- * This {@link ShortAccess} is immutable; any attempt to changes its values will result in a
+ * This {@link ShortArray} is immutable; any attempt to changes its values will result in a
  * {@link UnsupportedOperationException}.
  * <p>
  * This data access is marked as volatile but always contain valid data.
  */
-public class ShortRasterAccess implements ShortAccess, SizableDataAccess, VolatileAccess {
+public class ShortRasterAccess extends ShortArray implements SizableDataAccess, VolatileAccess {
 
-    private final Raster raster;
-    private final DataBuffer dataBuffer;
-    private final int width;
-    private final int planeSize;
-    private final boolean canUseDataBuffer;
     private final int size;
 
     /**
@@ -33,28 +28,9 @@ public class ShortRasterAccess implements ShortAccess, SizableDataAccess, Volati
      * @throws NullPointerException if the provided image is null
      */
     public ShortRasterAccess(Raster raster) {
-        this.raster = raster;
-        this.dataBuffer = this.raster.getDataBuffer();
+        super(createArrayFromRaster(raster));
 
-        this.width = this.raster.getWidth();
-        this.planeSize = width * this.raster.getHeight();
-
-        this.canUseDataBuffer = (this.dataBuffer instanceof DataBufferUShort || this.dataBuffer instanceof DataBufferShort) &&
-                AccessTools.isSampleModelDirectlyUsable(this.raster);
-
-        this.size = AccessTools.getSizeOfDataBufferInBytes(this.dataBuffer);
-    }
-
-    @Override
-    public short getValue(int index) {
-        int b = index / planeSize;
-        int xyIndex = index % planeSize;
-
-        if (canUseDataBuffer) {
-            return (short) dataBuffer.getElem(b, xyIndex);
-        } else {
-            return (short) raster.getSample(xyIndex % width, xyIndex / width, b);
-        }
+        this.size = AccessTools.getSizeOfDataBufferInBytes(raster.getDataBuffer());
     }
 
     @Override
@@ -70,5 +46,33 @@ public class ShortRasterAccess implements ShortAccess, SizableDataAccess, Volati
     @Override
     public boolean isValid() {
         return true;
+    }
+
+    private static short[] createArrayFromRaster(Raster raster) {
+        int width = raster.getWidth();
+        int height = raster.getHeight();
+        int planeSize = width * height;
+        int numBands = raster.getNumBands();
+
+        short[] array = new short[planeSize * numBands];
+        if (AccessTools.isSampleModelDirectlyUsable(raster) && (raster.getDataBuffer() instanceof DataBufferUShort || raster.getDataBuffer() instanceof DataBufferShort)) {
+            DataBuffer dataBuffer = raster.getDataBuffer();
+
+            for (int b=0; b<numBands; b++) {
+                for (int i=0; i<planeSize; i++) {
+                    array[i + b * planeSize] = (short) dataBuffer.getElem(b, i);
+                }
+            }
+        } else {
+            for (int b=0; b<numBands; b++) {
+                for (int y=0; y<height; y++) {
+                    for (int x=0; x<width; x++) {
+                        array[x + y * width + b * planeSize] = (short) raster.getSample(x, y, b);
+                    }
+                }
+            }
+        }
+
+        return array;
     }
 }

--- a/src/test/java/qupath/ext/imglib2/accesses/TestByteRasterAccess.java
+++ b/src/test/java/qupath/ext/imglib2/accesses/TestByteRasterAccess.java
@@ -36,9 +36,9 @@ public class TestByteRasterAccess {
         DataBuffer dataBuffer = new DataBufferByte(pixels, nChannels);
         Raster raster = Utils.createRaster(dataBuffer, width, height, nChannels);
 
-        ByteRasterAccess bufferedImageAccess = new ByteRasterAccess(raster);
+        ByteRasterAccess rasterAccess = new ByteRasterAccess(raster);
 
-        assertArrayEqualsByteAccess(expectedPixels, bufferedImageAccess);
+        assertArrayEqualsByteAccess(expectedPixels, rasterAccess);
     }
 
     private void assertArrayEqualsByteAccess(byte[] expectedArray, ByteAccess access) {

--- a/src/test/java/qupath/ext/imglib2/accesses/TestDoubleRasterAccess.java
+++ b/src/test/java/qupath/ext/imglib2/accesses/TestDoubleRasterAccess.java
@@ -36,9 +36,9 @@ public class TestDoubleRasterAccess {
         DataBuffer dataBuffer = new DataBufferDouble(pixels, nChannels);
         Raster raster = Utils.createRaster(dataBuffer, width, height, nChannels);
 
-        DoubleRasterAccess bufferedImageAccess = new DoubleRasterAccess(raster);
+        DoubleRasterAccess rasterAccess = new DoubleRasterAccess(raster);
 
-        assertArrayEqualsDoubleAccess(expectedPixels, bufferedImageAccess);
+        assertArrayEqualsDoubleAccess(expectedPixels, rasterAccess);
     }
 
     private void assertArrayEqualsDoubleAccess(double[] expectedArray, DoubleAccess access) {

--- a/src/test/java/qupath/ext/imglib2/accesses/TestFloatRasterAccess.java
+++ b/src/test/java/qupath/ext/imglib2/accesses/TestFloatRasterAccess.java
@@ -36,9 +36,9 @@ public class TestFloatRasterAccess {
         DataBuffer dataBuffer = new DataBufferFloat(pixels, nChannels);
         Raster raster = Utils.createRaster(dataBuffer, width, height, nChannels);
 
-        FloatRasterAccess bufferedImageAccess = new FloatRasterAccess(raster);
+        FloatRasterAccess rasterAccess = new FloatRasterAccess(raster);
 
-        assertArrayEqualsFloatAccess(expectedPixels, bufferedImageAccess);
+        assertArrayEqualsFloatAccess(expectedPixels, rasterAccess);
     }
 
     private void assertArrayEqualsFloatAccess(float[] expectedArray, FloatAccess access) {

--- a/src/test/java/qupath/ext/imglib2/accesses/TestIntRasterAccess.java
+++ b/src/test/java/qupath/ext/imglib2/accesses/TestIntRasterAccess.java
@@ -36,9 +36,9 @@ public class TestIntRasterAccess {
         DataBuffer dataBuffer = new DataBufferInt(pixels, nChannels);
         Raster raster = Utils.createRaster(dataBuffer, width, height, nChannels);
 
-        IntRasterAccess bufferedImageAccess = new IntRasterAccess(raster);
+        IntRasterAccess rasterAccess = new IntRasterAccess(raster);
 
-        assertArrayEqualsIntAccess(expectedPixels, bufferedImageAccess);
+        assertArrayEqualsIntAccess(expectedPixels, rasterAccess);
     }
 
     private void assertArrayEqualsIntAccess(int[] expectedArray, IntAccess access) {

--- a/src/test/java/qupath/ext/imglib2/accesses/TestShortRasterAccess.java
+++ b/src/test/java/qupath/ext/imglib2/accesses/TestShortRasterAccess.java
@@ -37,9 +37,9 @@ public class TestShortRasterAccess {
         DataBuffer dataBuffer = new DataBufferShort(pixels, nChannels);
         Raster raster = Utils.createRaster(dataBuffer, width, height, nChannels);
 
-        ShortRasterAccess bufferedImageAccess = new ShortRasterAccess(raster);
+        ShortRasterAccess rasterAccess = new ShortRasterAccess(raster);
 
-        assertArrayEqualsShortAccess(expectedPixels, bufferedImageAccess);
+        assertArrayEqualsShortAccess(expectedPixels, rasterAccess);
     }
 
     @Test


### PR DESCRIPTION
Change all `DataAccess` by making them implement `ArrayDataAccess`.

Before this PR, when a tile of an image was accessed for the first time, the corresponding `BufferedImage` (or `Raster`) was saved, and getting a pixel of this tile was fetching the pixel from the `BufferedImage` / `Raster`.

With this PR, when a tile of an image is accessed for the first time, an array is created and populated by all pixels of the corresponding `BufferedImage` / `Raster`. Getting a pixel of this tile is now simply an array access.

In terms of performance, with this PR, the first access to a pixel belonging to a tile is slower, but all subsequent access to pixels of the same tile are faster.